### PR TITLE
feat: expand MCP to full professional After Effects toolset (65 tools)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -39,30 +39,30 @@ function getAETempDir(): string {
 function readResultsFromTempFile(): string {
   try {
     const tempFilePath = path.join(getAETempDir(), 'ae_mcp_result.json');
-    
+
     // Add debugging info
     console.error(`Checking for results at: ${tempFilePath}`);
-    
+
     if (fs.existsSync(tempFilePath)) {
       // Get file stats to check modification time
       const stats = fs.statSync(tempFilePath);
       console.error(`Result file exists, last modified: ${stats.mtime.toISOString()}`);
-      
+
       const content = fs.readFileSync(tempFilePath, 'utf8');
       console.error(`Result file content length: ${content.length} bytes`);
-      
+
       // If the result file is older than 30 seconds, warn the user
       const thirtySecondsAgo = new Date(Date.now() - 30 * 1000);
       if (stats.mtime < thirtySecondsAgo) {
         console.error(`WARNING: Result file is older than 30 seconds. After Effects may not be updating results.`);
-        return JSON.stringify({ 
+        return JSON.stringify({
           warning: "Result file appears to be stale (not recently updated).",
           message: "This could indicate After Effects is not properly writing results or the MCP Bridge Auto panel isn't running.",
           lastModified: stats.mtime.toISOString(),
           originalContent: content
         });
       }
-      
+
       return content;
     } else {
       console.error(`Result file not found at: ${tempFilePath}`);
@@ -125,19 +125,27 @@ function writeCommandFile(command: string, args: Record<string, any> = {}): void
 function clearResultsFile(): void {
   try {
     const resultFile = path.join(getAETempDir(), 'ae_mcp_result.json');
-    
+
     // Write a placeholder message to indicate the file is being reset
     const resetData = {
       status: "waiting",
       message: "Waiting for new result from After Effects...",
       timestamp: new Date().toISOString()
     };
-    
+
     fs.writeFileSync(resultFile, JSON.stringify(resetData, null, 2));
     console.error(`Results file cleared at ${resultFile}`);
   } catch (error) {
     console.error("Error clearing results file:", error);
   }
+}
+
+// Unified bridge helper - clears results, writes command, waits for result
+async function callBridge(command: string, params: Record<string, any> = {}, timeoutMs: number = 8000): Promise<{ content: Array<{ type: "text"; text: string }> }> {
+  clearResultsFile();
+  writeCommandFile(command, params);
+  const result = await waitForBridgeResult(command, timeoutMs, 250);
+  return { content: [{ type: "text", text: result }] };
 }
 
 // Add a resource to expose project compositions
@@ -171,9 +179,9 @@ server.tool(
   async ({ script, parameters = {} }) => {
     // Validate that script is safe (only allow predefined scripts)
     const allowedScripts = [
-      "listCompositions", 
-      "getProjectInfo", 
-      "getLayerInfo", 
+      "listCompositions",
+      "getProjectInfo",
+      "getLayerInfo",
       "createComposition",
       "createTextLayer",
       "createShapeLayer",
@@ -184,9 +192,57 @@ server.tool(
       "applyEffect",
       "applyEffectTemplate",
       "test-animation",
-      "bridgeTestEffects"
+      "bridgeTestEffects",
+      "createNullObject",
+      "createCamera",
+      "createLight",
+      "deleteLayer",
+      "duplicateLayer",
+      "reorderLayer",
+      "renameLayer",
+      "setLayerParent",
+      "setLayerBlendMode",
+      "setLayerTrackMatte",
+      "setLayerFlags",
+      "precomposeLayer",
+      "moveLayerToTime",
+      "trimLayer",
+      "splitLayer",
+      "addMask",
+      "setMaskProperties",
+      "deleteMask",
+      "importFootage",
+      "saveProject",
+      "replaceFootage",
+      "addToRenderQueue",
+      "renderQueue",
+      "exportFrame",
+      "setCompositionSettings",
+      "setWorkArea",
+      "trimCompToWorkArea",
+      "addMarker",
+      "removeEffect",
+      "getEffectParams",
+      "setEffectParam",
+      "setAudioLevel",
+      "enableTimeRemap",
+      "setTimeRemapKeyframe",
+      "executeScript",
+      "getCompFrame",
+      "createCaption",
+      "createZoomEffect",
+      "addTextAnimator",
+      "getAudioWaveform",
+      "alignLayers",
+      "distributeKeyframes",
+      "setLayerStretch",
+      "duplicateComposition",
+      "getRendererInfo",
+      "setRenderer",
+      "addLutEffect",
+      "createSlideShow"
     ];
-    
+
     if (!allowedScripts.includes(script)) {
       return {
         content: [
@@ -202,10 +258,10 @@ server.tool(
     try {
       // Clear any stale result data
       clearResultsFile();
-      
+
       // Write command to file for After Effects to pick up
       writeCommandFile(script, parameters);
-      
+
       return {
         content: [
           {
@@ -324,55 +380,95 @@ server.tool(
           type: "text",
           text: `# After Effects MCP Integration Help
 
-To use this integration with After Effects, follow these steps:
+## Setup
+1. Run \`node install-bridge.js\` with administrator privileges
+2. Launch Adobe After Effects and open a project
+3. Open Window > mcp-bridge-auto.jsx panel in After Effects
+4. The panel automatically polls for commands
 
- 1. **Install the scripts in After Effects**
-   - Run \`node install-bridge.js\` with administrator privileges
-   - This copies the necessary scripts to your After Effects installation
+## Core Tools
+- \`get-results\`: Get results from last executed command
+- \`run-script\`: Queue a named script for execution
+- \`get-help\`: Show this help
 
-2. **Open After Effects**
-   - Launch Adobe After Effects 
-   - Open a project that you want to work with
+## Composition Tools
+- \`create-composition\`: Create a new composition
+- \`set-composition-settings\`: Update comp settings (name, size, fps, duration)
+- \`set-work-area\`: Set composition work area start and duration
+- \`trim-comp-to-work-area\`: Trim comp duration to work area
+- \`duplicate-composition\`: Duplicate a composition
+- \`get-renderer-info\`: Get available renderers for a comp
+- \`set-renderer\`: Set 3D renderer (Classic 3D or C4D)
+- \`add-marker\`: Add comp or layer marker
 
-3. **Open the MCP Bridge Auto panel**
-   - In After Effects, go to Window > mcp-bridge-auto.jsx
-   - The panel will automatically check for commands every few seconds
+## Layer Creation
+- \`create-text-layer\`: Create a text layer
+- \`create-shape-layer\`: Create a shape layer
+- \`create-solid-layer\`: Create a solid/adjustment layer
+- \`create-null-object\`: Create a null object layer
+- \`create-camera\`: Create a camera layer
+- \`create-light\`: Create a light layer
+- \`create-caption\`: Create a styled caption text layer
+- \`create-slide-show\`: Create a slideshow from images
 
-4. **Run scripts through MCP**
-   - Use the \`run-script\` tool to queue a command
-   - The Auto panel will detect and run the command automatically
-   - Results will be saved to a temp file
+## Layer Operations
+- \`delete-layer\`: Remove a layer
+- \`duplicate-layer\`: Duplicate a layer
+- \`reorder-layer\`: Move layer to new index
+- \`rename-layer\`: Rename a layer
+- \`set-layer-parent\`: Set layer parent (or clear)
+- \`set-layer-blend-mode\`: Set blending mode
+- \`set-layer-track-matte\`: Set track matte type
+- \`set-layer-flags\`: Set solo, shy, locked, motionBlur, 3D, etc.
+- \`set-layer-properties\`: Set position, scale, rotation, opacity
+- \`set-layer-stretch\`: Set layer time stretch percentage
+- \`move-layer-to-time\`: Move layer start time
+- \`trim-layer\`: Trim layer in/out points
+- \`split-layer\`: Split layer at a time point
+- \`precompose-layer\`: Precompose one or more layers
 
-5. **Get results through MCP**
-   - After a command is executed, use the \`get-results\` tool
-   - This will retrieve the results from After Effects
+## Keyframes & Animation
+- \`set-layer-keyframe\`: Set a keyframe on a layer property
+- \`set-layer-expression\`: Set/remove an expression
+- \`create-zoom-effect\`: Add zoom (scale) animation with easing
+- \`add-text-animator\`: Add a text animator with range selector
+- \`distribute-keyframes\`: Add multiple keyframes at once
+- \`align-layers\`: Align multiple layers to comp or each other
+- \`enable-time-remap\`: Enable time remapping
+- \`set-time-remap-keyframe\`: Set time remap keyframe
 
-Available scripts:
-- getProjectInfo: Information about the current project
-- listCompositions: List all compositions in the project
-- getLayerInfo: Information about layers in the active composition
-- createComposition: Create a new composition
-- createTextLayer: Create a new text layer
-- createShapeLayer: Create a new shape layer
-- createSolidLayer: Create a new solid layer
-- setLayerProperties: Set properties for a layer
-- setLayerKeyframe: Set a keyframe for a layer property
-- setLayerExpression: Set an expression for a layer property
-- applyEffect: Apply an effect to a layer
-- applyEffectTemplate: Apply a predefined effect template to a layer
+## Effects
+- \`apply-effect\`: Apply an effect by name or match name
+- \`apply-effect-template\`: Apply a predefined effect template
+- \`remove-effect\`: Remove an effect from a layer
+- \`get-effect-params\`: Get all parameters of an effect
+- \`set-effect-param\`: Set a specific effect parameter
+- \`set-audio-level\`: Set audio level (with optional keyframe)
+- \`add-lut-effect\`: Apply an Apply Color LUT effect
 
-Effect Templates:
-- gaussian-blur: Simple Gaussian blur effect
-- directional-blur: Motion blur in a specific direction
-- color-balance: Adjust hue, lightness, and saturation
-- brightness-contrast: Basic brightness and contrast adjustment
-- curves: Advanced color adjustment using curves
-- glow: Add a glow effect to elements
-- drop-shadow: Add a customizable drop shadow
-- cinematic-look: Combination of effects for a cinematic appearance
-- text-pop: Effects to make text stand out (glow and shadow)
+## Masks
+- \`add-mask\`: Add a mask (rectangle, ellipse, or freeform)
+- \`set-mask-properties\`: Set mask feather, opacity, expansion, mode
+- \`delete-mask\`: Remove a mask
 
-Note: The auto-running panel can be left open in After Effects to continuously listen for commands from external applications.`
+## Project & Footage
+- \`import-footage\`: Import a file as footage
+- \`replace-footage\`: Replace footage source
+- \`save-project\`: Save the current project
+
+## Render & Export
+- \`add-to-render-queue\`: Add comp to render queue
+- \`render-queue\`: Control render queue (start/stop/clear/status)
+- \`export-frame\`: Export a single frame as PNG
+- \`get-comp-frame\`: Save a comp frame to disk
+
+## Scripting
+- \`execute-script\`: Run arbitrary ExtendScript code
+- \`get-audio-waveform\`: Get audio level data for a layer
+
+## Effect Templates
+- gaussian-blur, directional-blur, color-balance, brightness-contrast
+- curves, glow, drop-shadow, cinematic-look, text-pop`
         }
       ]
     };
@@ -396,36 +492,10 @@ server.tool(
       b: z.number().int().min(0).max(255)
     }).optional().describe("Background color of the composition (RGB values 0-255)")
   },
-  async (params) => {
-    try {
-      // Write command to file for After Effects to pick up
-      writeCommandFile("createComposition", params);
-      
-      return {
-        content: [
-          {
-            type: "text",
-            text: `Command to create composition "${params.name}" has been queued.\n` +
-                  `Please ensure the "MCP Bridge Auto" panel is open in After Effects.\n` +
-                  `Use the "get-results" tool after a few seconds to check for results.`
-          }
-        ]
-      };
-    } catch (error) {
-      return {
-        content: [
-          {
-            type: "text",
-            text: `Error queuing composition creation: ${String(error)}`
-          }
-        ],
-        isError: true
-      };
-    }
-  }
+  async (params) => callBridge("createComposition", params)
 );
 
-// --- BEGIN NEW TOOLS --- 
+// --- BEGIN NEW TOOLS ---
 
 // Zod schema for common layer identification
 const LayerIdentifierSchema = {
@@ -447,32 +517,7 @@ server.tool(
     timeInSeconds: z.number().describe("The time (in seconds) for the keyframe."),
     value: KeyframeValueSchema
   },
-  async (parameters) => {
-    try {
-      // Queue the command for After Effects
-      writeCommandFile("setLayerKeyframe", parameters);
-      
-      return {
-        content: [
-          {
-            type: "text",
-            text: `Command to set keyframe for "${parameters.propertyName}" on layer ${parameters.layerIndex} in comp ${parameters.compIndex} has been queued.\n` +
-                  `Use the "get-results" tool after a few seconds to check for confirmation.`
-          }
-        ]
-      };
-    } catch (error) {
-      return {
-        content: [
-          {
-            type: "text",
-            text: `Error queuing setLayerKeyframe command: ${String(error)}`
-          }
-        ],
-        isError: true
-      };
-    }
-  }
+  async (parameters) => callBridge("setLayerKeyframe", parameters)
 );
 
 // Tool for setting a layer expression
@@ -484,37 +529,12 @@ server.tool(
     propertyName: z.string().describe("Name of the property to apply the expression to (e.g., 'Position', 'Scale', 'Rotation', 'Opacity')."),
     expressionString: z.string().describe("The JavaScript expression string. Provide an empty string (\"\") to remove the expression.")
   },
-  async (parameters) => {
-    try {
-      // Queue the command for After Effects
-      writeCommandFile("setLayerExpression", parameters);
-      
-      return {
-        content: [
-          {
-            type: "text",
-            text: `Command to set expression for "${parameters.propertyName}" on layer ${parameters.layerIndex} in comp ${parameters.compIndex} has been queued.\n` +
-                  `Use the "get-results" tool after a few seconds to check for confirmation.`
-          }
-        ]
-      };
-    } catch (error) {
-      return {
-        content: [
-          {
-            type: "text",
-            text: `Error queuing setLayerExpression command: ${String(error)}`
-          }
-        ],
-        isError: true
-      };
-    }
-  }
+  async (parameters) => callBridge("setLayerExpression", parameters)
 );
 
-// --- END NEW TOOLS --- 
+// --- END NEW TOOLS ---
 
-// --- BEGIN NEW TESTING TOOL --- 
+// --- BEGIN NEW TESTING TOOL ---
 // Add a special tool for directly testing the keyframe functionality
 server.tool(
   "test-animation",
@@ -529,7 +549,7 @@ server.tool(
       // Generate a unique timestamp
       const timestamp = new Date().getTime();
       const tempFile = path.join(process.env.TEMP || process.env.TMP || os.tmpdir(), `ae_test_${timestamp}.jsx`);
-      
+
       // Create a direct test script that doesn't rely on command files
       let scriptContent = "";
       if (params.operation === "keyframe") {
@@ -541,16 +561,16 @@ server.tool(
             var prop = layer.property("Transform").property("Opacity");
             var time = 1; // 1 second
             var value = 25; // 25% opacity
-            
+
             // Set a keyframe
             prop.setValueAtTime(time, value);
-            
+
             // Write direct result
             var resultFile = new File("${path.join(process.env.TEMP || process.env.TMP || os.tmpdir(), 'ae_test_result.txt').replace(/\\/g, '\\\\')}");
             resultFile.open("w");
             resultFile.write("SUCCESS: Added keyframe at time " + time + " with value " + value);
             resultFile.close();
-            
+
             // Visual feedback
             alert("Test successful: Added opacity keyframe at " + time + "s with value " + value + "%");
           } catch (e) {
@@ -558,7 +578,7 @@ server.tool(
             errorFile.open("w");
             errorFile.write("ERROR: " + e.toString());
             errorFile.close();
-            
+
             alert("Test failed: " + e.toString());
           }
         `;
@@ -570,16 +590,16 @@ server.tool(
             var layer = comp.layers[${params.layerIndex}];
             var prop = layer.property("Transform").property("Position");
             var expression = "wiggle(3, 30)";
-            
+
             // Set the expression
             prop.expression = expression;
-            
+
             // Write direct result
             var resultFile = new File("${path.join(process.env.TEMP || process.env.TMP || os.tmpdir(), 'ae_test_result.txt').replace(/\\/g, '\\\\')}");
             resultFile.open("w");
             resultFile.write("SUCCESS: Added expression: " + expression);
             resultFile.close();
-            
+
             // Visual feedback
             alert("Test successful: Added position expression: " + expression);
           } catch (e) {
@@ -587,16 +607,16 @@ server.tool(
             errorFile.open("w");
             errorFile.write("ERROR: " + e.toString());
             errorFile.close();
-            
+
             alert("Test failed: " + e.toString());
           }
         `;
       }
-      
+
       // Write the script to a temp file
       fs.writeFileSync(tempFile, scriptContent);
       console.error(`Written test script to: ${tempFile}`);
-      
+
       // Tell the user what to do
       return {
         content: [
@@ -626,7 +646,7 @@ This bypasses the MCP Bridge Auto panel and will directly modify the specified l
     }
   }
 );
-// --- END NEW TESTING TOOL --- 
+// --- END NEW TESTING TOOL ---
 
 // --- BEGIN NEW EFFECTS TOOLS ---
 
@@ -643,32 +663,7 @@ server.tool(
     presetPath: z.string().optional().describe("Optional path to an effect preset file (.ffx)."),
     effectSettings: z.record(z.any()).optional().describe("Optional parameters for the effect (e.g., { 'Blurriness': 25 }).")
   },
-  async (parameters) => {
-    try {
-      // Queue the command for After Effects
-      writeCommandFile("applyEffect", parameters);
-      
-      return {
-        content: [
-          {
-            type: "text",
-            text: `Command to apply effect to layer ${parameters.layerIndex} in composition ${parameters.compIndex} has been queued.\n` +
-                  `Use the "get-results" tool after a few seconds to check for confirmation.`
-          }
-        ]
-      };
-    } catch (error) {
-      return {
-        content: [
-          {
-            type: "text",
-            text: `Error queuing apply-effect command: ${String(error)}`
-          }
-        ],
-        isError: true
-      };
-    }
-  }
+  async (parameters) => callBridge("applyEffect", parameters)
 );
 
 // Add a tool for applying effect templates
@@ -679,9 +674,9 @@ server.tool(
     compIndex: z.number().int().positive().describe("1-based index of the target composition in the project panel."),
     layerIndex: z.number().int().positive().describe("1-based index of the target layer within the composition."),
     templateName: z.enum([
-      "gaussian-blur", 
-      "directional-blur", 
-      "color-balance", 
+      "gaussian-blur",
+      "directional-blur",
+      "color-balance",
       "brightness-contrast",
       "curves",
       "glow",
@@ -691,32 +686,7 @@ server.tool(
     ]).describe("Name of the effect template to apply."),
     customSettings: z.record(z.any()).optional().describe("Optional custom settings to override defaults.")
   },
-  async (parameters) => {
-    try {
-      // Queue the command for After Effects
-      writeCommandFile("applyEffectTemplate", parameters);
-      
-      return {
-        content: [
-          {
-            type: "text",
-            text: `Command to apply effect template '${parameters.templateName}' to layer ${parameters.layerIndex} in composition ${parameters.compIndex} has been queued.\n` +
-                  `Use the "get-results" tool after a few seconds to check for confirmation.`
-          }
-        ]
-      };
-    } catch (error) {
-      return {
-        content: [
-          {
-            type: "text",
-            text: `Error queuing apply-effect-template command: ${String(error)}`
-          }
-        ],
-        isError: true
-      };
-    }
-  }
+  async (parameters) => callBridge("applyEffectTemplate", parameters)
 );
 
 // --- END NEW EFFECTS TOOLS ---
@@ -732,37 +702,7 @@ server.tool(
     effectMatchName: z.string().optional().describe("After Effects internal name for the effect (more reliable, e.g., 'ADBE Gaussian Blur 2')."),
     effectSettings: z.record(z.any()).optional().describe("Optional parameters for the effect (e.g., { 'Blurriness': 25 }).")
   },
-  async (parameters) => {
-    try {
-      // Queue the command for After Effects
-      writeCommandFile("applyEffect", parameters);
-      
-      // Wait a bit for After Effects to process the command
-      await new Promise(resolve => setTimeout(resolve, 1000));
-      
-      // Get the results
-      const result = readResultsFromTempFile();
-      
-      return {
-        content: [
-          {
-            type: "text",
-            text: result
-          }
-        ]
-      };
-    } catch (error) {
-      return {
-        content: [
-          {
-            type: "text",
-            text: `Error applying effect: ${String(error)}`
-          }
-        ],
-        isError: true
-      };
-    }
-  }
+  async (parameters) => callBridge("applyEffect", parameters)
 );
 
 // Add direct MCP function for applying effect templates
@@ -773,9 +713,9 @@ server.tool(
     compIndex: z.number().int().positive().describe("1-based index of the target composition in the project panel."),
     layerIndex: z.number().int().positive().describe("1-based index of the target layer within the composition."),
     templateName: z.enum([
-      "gaussian-blur", 
-      "directional-blur", 
-      "color-balance", 
+      "gaussian-blur",
+      "directional-blur",
+      "color-balance",
       "brightness-contrast",
       "curves",
       "glow",
@@ -785,37 +725,7 @@ server.tool(
     ]).describe("Name of the effect template to apply."),
     customSettings: z.record(z.any()).optional().describe("Optional custom settings to override defaults.")
   },
-  async (parameters) => {
-    try {
-      // Queue the command for After Effects
-      writeCommandFile("applyEffectTemplate", parameters);
-      
-      // Wait a bit for After Effects to process the command
-      await new Promise(resolve => setTimeout(resolve, 1000));
-      
-      // Get the results
-      const result = readResultsFromTempFile();
-      
-      return {
-        content: [
-          {
-            type: "text",
-            text: result
-          }
-        ]
-      };
-    } catch (error) {
-      return {
-        content: [
-          {
-            type: "text",
-            text: `Error applying effect template: ${String(error)}`
-          }
-        ],
-        isError: true
-      };
-    }
-  }
+  async (parameters) => callBridge("applyEffectTemplate", parameters)
 );
 
 // Update help information to include the new effects tools
@@ -872,30 +782,6 @@ The following predefined effect templates are available:
 - \`drop-shadow\`: Add a customizable drop shadow
 - \`cinematic-look\`: Combination of effects for a cinematic appearance
 - \`text-pop\`: Effects to make text stand out (glow and shadow)
-
-## Example Usage
-To apply a Gaussian blur effect:
-
-\`\`\`json
-{
-  "compIndex": 1,
-  "layerIndex": 1,
-  "effectMatchName": "ADBE Gaussian Blur 2",
-  "effectSettings": {
-    "Blurriness": 25
-  }
-}
-\`\`\`
-
-To apply the "cinematic-look" template:
-
-\`\`\`json
-{
-  "compIndex": 1,
-  "layerIndex": 1,
-  "templateName": "cinematic-look"
-}
-\`\`\`
 `
         }
       ]
@@ -908,36 +794,733 @@ server.tool(
   "run-bridge-test",
   "Run the bridge test effects script to verify communication and apply test effects",
   {},
-  async () => {
-    try {
-      // Clear any stale result data
-      clearResultsFile();
-      
-      // Write command to file for After Effects to pick up
-      writeCommandFile("bridgeTestEffects", {});
-      
-      return {
-        content: [
-          {
-            type: "text",
-            text: `Bridge test effects command has been queued.\n` +
-                  `Please ensure the "MCP Bridge Auto" panel is open in After Effects.\n` +
-                  `Use the "get-results" tool after a few seconds to check for the test results.`
-          }
-        ]
-      };
-    } catch (error) {
-      return {
-        content: [
-          {
-            type: "text",
-            text: `Error queuing bridge test command: ${String(error)}`
-          }
-        ],
-        isError: true
-      };
-    }
-  }
+  async () => callBridge("bridgeTestEffects", {})
+);
+
+// ============================================================
+// NEW EXPANDED TOOLS
+// ============================================================
+
+// create-null-object
+server.tool(
+  "create-null-object",
+  "Create a null object layer in a composition. Null objects are useful as parent controllers.",
+  {
+    compIndex: z.number().int().positive().describe("1-based index of the target composition."),
+    name: z.string().optional().describe("Name for the null object layer (default: 'Null')."),
+    startTime: z.number().optional().describe("Start time in seconds (default: 0)."),
+    duration: z.number().optional().describe("Duration in seconds. 0 = use comp duration.")
+  },
+  async (params) => callBridge("createNullObject", params)
+);
+
+// create-camera
+server.tool(
+  "create-camera",
+  "Create a camera layer in a 3D composition.",
+  {
+    compIndex: z.number().int().positive().describe("1-based index of the target composition."),
+    name: z.string().optional().describe("Name for the camera layer (default: 'Camera 1')."),
+    preset: z.enum(["15mm","20mm","24mm","28mm","35mm","50mm","80mm","85mm","135mm","200mm","custom"]).optional().describe("Camera lens preset (default: '50mm')."),
+    zoom: z.number().optional().describe("Zoom value in pixels (overrides preset if provided)."),
+    filmSize: z.number().optional().describe("Film size in mm (default: 36).")
+  },
+  async (params) => callBridge("createCamera", params)
+);
+
+// create-light
+server.tool(
+  "create-light",
+  "Create a light layer in a 3D composition.",
+  {
+    compIndex: z.number().int().positive().describe("1-based index of the target composition."),
+    name: z.string().optional().describe("Name for the light layer (default: 'Light 1')."),
+    lightType: z.enum(["PARALLEL","SPOT","POINT","AMBIENT"]).optional().describe("Type of light (default: POINT)."),
+    color: z.array(z.number()).optional().describe("RGB color 0-1, e.g. [1,1,1] for white."),
+    intensity: z.number().optional().describe("Light intensity in percent (default: 100)."),
+    castsShadows: z.boolean().optional().describe("Whether the light casts shadows (default: false)."),
+    coneAngle: z.number().optional().describe("Cone angle in degrees for SPOT lights (default: 90)."),
+    coneFeather: z.number().optional().describe("Cone feather percentage for SPOT lights (default: 50).")
+  },
+  async (params) => callBridge("createLight", params)
+);
+
+// delete-layer
+server.tool(
+  "delete-layer",
+  "Remove a layer from a composition.",
+  {
+    compIndex: z.number().int().positive().describe("1-based index of the target composition."),
+    layerIndex: z.number().int().positive().describe("1-based index of the layer to delete.")
+  },
+  async (params) => callBridge("deleteLayer", params)
+);
+
+// duplicate-layer
+server.tool(
+  "duplicate-layer",
+  "Duplicate a layer in a composition.",
+  {
+    compIndex: z.number().int().positive().describe("1-based index of the target composition."),
+    layerIndex: z.number().int().positive().describe("1-based index of the layer to duplicate.")
+  },
+  async (params) => callBridge("duplicateLayer", params)
+);
+
+// reorder-layer
+server.tool(
+  "reorder-layer",
+  "Move a layer to a new position in the layer stack.",
+  {
+    compIndex: z.number().int().positive().describe("1-based index of the target composition."),
+    layerIndex: z.number().int().positive().describe("1-based index of the layer to move."),
+    newIndex: z.number().int().positive().describe("Target 1-based index position.")
+  },
+  async (params) => callBridge("reorderLayer", params)
+);
+
+// rename-layer
+server.tool(
+  "rename-layer",
+  "Rename a layer in a composition.",
+  {
+    compIndex: z.number().int().positive().describe("1-based index of the target composition."),
+    layerIndex: z.number().int().positive().describe("1-based index of the layer to rename."),
+    newName: z.string().describe("New name for the layer.")
+  },
+  async (params) => callBridge("renameLayer", params)
+);
+
+// set-layer-parent
+server.tool(
+  "set-layer-parent",
+  "Set or clear the parent layer for a layer (for parenting/rigging).",
+  {
+    compIndex: z.number().int().positive().describe("1-based index of the target composition."),
+    layerIndex: z.number().int().positive().describe("1-based index of the child layer."),
+    parentLayerIndex: z.number().int().min(0).describe("1-based index of the parent layer. Use 0 to clear the parent.")
+  },
+  async (params) => callBridge("setLayerParent", params)
+);
+
+// set-layer-blend-mode
+server.tool(
+  "set-layer-blend-mode",
+  "Set the blending mode of a layer.",
+  {
+    compIndex: z.number().int().positive().describe("1-based index of the target composition."),
+    layerIndex: z.number().int().positive().describe("1-based index of the target layer."),
+    blendMode: z.enum([
+      "NORMAL","DISSOLVE","DANCING_DISSOLVE","DARKEN","MULTIPLY","COLOR_BURN",
+      "CLASSIC_COLOR_BURN","LINEAR_BURN","DARKER_COLOR","ADD","LIGHTEN","SCREEN",
+      "COLOR_DODGE","CLASSIC_COLOR_DODGE","LINEAR_DODGE","LIGHTER_COLOR","OVERLAY",
+      "SOFT_LIGHT","HARD_LIGHT","LINEAR_LIGHT","VIVID_LIGHT","PIN_LIGHT","HARD_MIX",
+      "DIFFERENCE","CLASSIC_DIFFERENCE","EXCLUSION","HUE","SATURATION","COLOR",
+      "LUMINOSITY","STENCIL_ALPHA","STENCIL_LUMA","SILHOUETTE_ALPHA","SILHOUETTE_LUMA",
+      "ALPHA_ADD","LUMINESCENT_PREMUL"
+    ]).describe("Blending mode to apply.")
+  },
+  async (params) => callBridge("setLayerBlendMode", params)
+);
+
+// set-layer-track-matte
+server.tool(
+  "set-layer-track-matte",
+  "Set the track matte type for a layer.",
+  {
+    compIndex: z.number().int().positive().describe("1-based index of the target composition."),
+    layerIndex: z.number().int().positive().describe("1-based index of the target layer."),
+    matteType: z.enum(["NONE","ALPHA","ALPHA_INVERTED","LUMA","LUMA_INVERTED"]).describe("Track matte type to apply.")
+  },
+  async (params) => callBridge("setLayerTrackMatte", params)
+);
+
+// set-layer-flags
+server.tool(
+  "set-layer-flags",
+  "Set boolean flags on a layer such as solo, shy, locked, motion blur, 3D, etc.",
+  {
+    compIndex: z.number().int().positive().describe("1-based index of the target composition."),
+    layerIndex: z.number().int().positive().describe("1-based index of the target layer."),
+    flags: z.object({
+      solo: z.boolean().optional(),
+      shy: z.boolean().optional(),
+      locked: z.boolean().optional(),
+      motionBlur: z.boolean().optional(),
+      enable3D: z.boolean().optional().describe("Enable 3D layer mode."),
+      adjustmentLayer: z.boolean().optional(),
+      collapseTransformation: z.boolean().optional(),
+      frameBlending: z.boolean().optional(),
+      frameBlendingType: z.enum(["FRAME_MIX","PIXEL_MOTION"]).optional()
+    }).describe("Object with flag properties to set.")
+  },
+  async (params) => callBridge("setLayerFlags", params)
+);
+
+// precompose-layer
+server.tool(
+  "precompose-layer",
+  "Precompose one or more layers into a new composition.",
+  {
+    compIndex: z.number().int().positive().describe("1-based index of the source composition."),
+    layerIndices: z.array(z.number().int().positive()).describe("Array of 1-based layer indices to precompose."),
+    newCompName: z.string().describe("Name for the new precomp."),
+    moveAllAttributes: z.boolean().optional().describe("Move all attributes into the new comp (default: true).")
+  },
+  async (params) => callBridge("precomposeLayer", params)
+);
+
+// move-layer-to-time
+server.tool(
+  "move-layer-to-time",
+  "Move a layer to start at a specific time in the composition.",
+  {
+    compIndex: z.number().int().positive().describe("1-based index of the target composition."),
+    layerIndex: z.number().int().positive().describe("1-based index of the target layer."),
+    startTime: z.number().describe("New start time in seconds.")
+  },
+  async (params) => callBridge("moveLayerToTime", params)
+);
+
+// trim-layer
+server.tool(
+  "trim-layer",
+  "Trim a layer's in point and/or out point.",
+  {
+    compIndex: z.number().int().positive().describe("1-based index of the target composition."),
+    layerIndex: z.number().int().positive().describe("1-based index of the target layer."),
+    inPoint: z.number().optional().describe("New in point in seconds (optional)."),
+    outPoint: z.number().optional().describe("New out point in seconds (optional).")
+  },
+  async (params) => callBridge("trimLayer", params)
+);
+
+// split-layer
+server.tool(
+  "split-layer",
+  "Split a layer at a specific time, creating two layers.",
+  {
+    compIndex: z.number().int().positive().describe("1-based index of the target composition."),
+    layerIndex: z.number().int().positive().describe("1-based index of the target layer."),
+    splitTime: z.number().describe("Time in seconds at which to split the layer.")
+  },
+  async (params) => callBridge("splitLayer", params)
+);
+
+// add-mask
+server.tool(
+  "add-mask",
+  "Add a mask to a layer.",
+  {
+    compIndex: z.number().int().positive().describe("1-based index of the target composition."),
+    layerIndex: z.number().int().positive().describe("1-based index of the target layer."),
+    maskShape: z.enum(["rectangle","ellipse","freeform"]).optional().describe("Shape type for the mask (default: rectangle)."),
+    vertices: z.array(z.array(z.number())).optional().describe("Array of [x,y] vertices for freeform masks."),
+    inverted: z.boolean().optional().describe("Whether the mask is inverted (default: false).")
+  },
+  async (params) => callBridge("addMask", params)
+);
+
+// set-mask-properties
+server.tool(
+  "set-mask-properties",
+  "Set properties of an existing mask on a layer.",
+  {
+    compIndex: z.number().int().positive().describe("1-based index of the target composition."),
+    layerIndex: z.number().int().positive().describe("1-based index of the target layer."),
+    maskIndex: z.number().int().positive().describe("1-based index of the mask."),
+    feather: z.union([z.number(), z.array(z.number())]).optional().describe("Feather value in pixels (single value or [x,y])."),
+    opacity: z.number().min(0).max(100).optional().describe("Mask opacity 0-100."),
+    expansion: z.number().optional().describe("Mask expansion in pixels."),
+    inverted: z.boolean().optional().describe("Whether the mask is inverted."),
+    mode: z.enum(["NONE","ADD","SUBTRACT","INTERSECT","LIGHTEN","DARKEN","DIFFERENCE"]).optional().describe("Mask blending mode.")
+  },
+  async (params) => callBridge("setMaskProperties", params)
+);
+
+// delete-mask
+server.tool(
+  "delete-mask",
+  "Delete a mask from a layer.",
+  {
+    compIndex: z.number().int().positive().describe("1-based index of the target composition."),
+    layerIndex: z.number().int().positive().describe("1-based index of the target layer."),
+    maskIndex: z.number().int().positive().describe("1-based index of the mask to delete.")
+  },
+  async (params) => callBridge("deleteMask", params)
+);
+
+// import-footage
+server.tool(
+  "import-footage",
+  "Import a file as footage into the project.",
+  {
+    filePath: z.string().describe("Absolute path to the file to import."),
+    name: z.string().optional().describe("Optional name for the footage item."),
+    sequenceOptions: z.object({
+      importAsSequence: z.boolean().optional(),
+      frameRate: z.number().optional()
+    }).optional().describe("Options for image sequence import.")
+  },
+  async (params) => callBridge("importFootage", params)
+);
+
+// save-project
+server.tool(
+  "save-project",
+  "Save the current After Effects project.",
+  {
+    filePath: z.string().optional().describe("Optional path to save the project to. Omit to save to current path.")
+  },
+  async (params) => callBridge("saveProject", params)
+);
+
+// replace-footage
+server.tool(
+  "replace-footage",
+  "Replace the source file for a footage item in the project.",
+  {
+    itemIndex: z.number().int().positive().describe("1-based index of the footage item in the project."),
+    newFilePath: z.string().describe("Absolute path to the new footage file.")
+  },
+  async (params) => callBridge("replaceFootage", params)
+);
+
+// add-to-render-queue
+server.tool(
+  "add-to-render-queue",
+  "Add a composition to the render queue with output settings.",
+  {
+    compIndex: z.number().int().positive().describe("1-based index of the composition to render."),
+    outputPath: z.string().describe("Full path for the output file."),
+    outputModuleTemplate: z.string().optional().describe("Output module template name (default: 'Lossless')."),
+    renderSettingsTemplate: z.string().optional().describe("Render settings template name (default: 'Best Settings').")
+  },
+  async (params) => callBridge("addToRenderQueue", params)
+);
+
+// render-queue
+server.tool(
+  "render-queue",
+  "Control the After Effects render queue.",
+  {
+    action: z.enum(["start","stop","clear","status"]).describe("Action to perform on the render queue.")
+  },
+  async (params) => callBridge("renderQueue", params)
+);
+
+// export-frame
+server.tool(
+  "export-frame",
+  "Export a single frame from a composition as a PNG file.",
+  {
+    compIndex: z.number().int().positive().describe("1-based index of the target composition."),
+    timeInSeconds: z.number().describe("Time in seconds for the frame to export."),
+    outputPath: z.string().describe("Full path for the output PNG file.")
+  },
+  async (params) => callBridge("exportFrame", params, 30000)
+);
+
+// set-composition-settings
+server.tool(
+  "set-composition-settings",
+  "Update settings of an existing composition.",
+  {
+    compIndex: z.number().int().positive().describe("1-based index of the composition to update."),
+    name: z.string().optional().describe("New name for the composition."),
+    width: z.number().int().positive().optional().describe("New width in pixels."),
+    height: z.number().int().positive().optional().describe("New height in pixels."),
+    frameRate: z.number().positive().optional().describe("New frame rate."),
+    duration: z.number().positive().optional().describe("New duration in seconds."),
+    pixelAspect: z.number().positive().optional().describe("New pixel aspect ratio."),
+    bgColor: z.union([
+      z.object({ r: z.number(), g: z.number(), b: z.number() }),
+      z.array(z.number())
+    ]).optional().describe("Background color as {r,g,b} (0-1) or [r,g,b] array.")
+  },
+  async (params) => callBridge("setCompositionSettings", params)
+);
+
+// set-work-area
+server.tool(
+  "set-work-area",
+  "Set the work area of a composition.",
+  {
+    compIndex: z.number().int().positive().describe("1-based index of the target composition."),
+    workAreaStart: z.number().describe("Work area start time in seconds."),
+    workAreaDuration: z.number().describe("Work area duration in seconds.")
+  },
+  async (params) => callBridge("setWorkArea", params)
+);
+
+// trim-comp-to-work-area
+server.tool(
+  "trim-comp-to-work-area",
+  "Trim a composition's duration to match its work area.",
+  {
+    compIndex: z.number().int().positive().describe("1-based index of the target composition.")
+  },
+  async (params) => callBridge("trimCompToWorkArea", params)
+);
+
+// add-marker
+server.tool(
+  "add-marker",
+  "Add a marker to a composition or layer.",
+  {
+    compIndex: z.number().int().positive().describe("1-based index of the target composition."),
+    layerIndex: z.number().int().min(0).optional().describe("1-based index of the target layer. Omit or use 0 for a comp marker."),
+    time: z.number().describe("Time in seconds for the marker."),
+    label: z.string().optional().describe("Label text for the marker."),
+    comment: z.string().optional().describe("Comment/description for the marker."),
+    duration: z.number().optional().describe("Duration of the marker in seconds (for span markers)."),
+    url: z.string().optional().describe("URL to associate with the marker.")
+  },
+  async (params) => callBridge("addMarker", params)
+);
+
+// remove-effect
+server.tool(
+  "remove-effect",
+  "Remove an effect from a layer.",
+  {
+    compIndex: z.number().int().positive().describe("1-based index of the target composition."),
+    layerIndex: z.number().int().positive().describe("1-based index of the target layer."),
+    effectName: z.string().optional().describe("Display name of the effect to remove."),
+    effectIndex: z.number().int().positive().optional().describe("1-based index of the effect to remove.")
+  },
+  async (params) => callBridge("removeEffect", params)
+);
+
+// get-effect-params
+server.tool(
+  "get-effect-params",
+  "Get all parameters of an effect on a layer.",
+  {
+    compIndex: z.number().int().positive().describe("1-based index of the target composition."),
+    layerIndex: z.number().int().positive().describe("1-based index of the target layer."),
+    effectName: z.string().optional().describe("Display name of the effect."),
+    effectIndex: z.number().int().positive().optional().describe("1-based index of the effect.")
+  },
+  async (params) => callBridge("getEffectParams", params)
+);
+
+// set-effect-param
+server.tool(
+  "set-effect-param",
+  "Set a specific parameter on an effect.",
+  {
+    compIndex: z.number().int().positive().describe("1-based index of the target composition."),
+    layerIndex: z.number().int().positive().describe("1-based index of the target layer."),
+    effectName: z.string().describe("Display name of the effect."),
+    paramName: z.string().describe("Name of the parameter to set."),
+    value: z.any().describe("New value for the parameter.")
+  },
+  async (params) => callBridge("setEffectParam", params)
+);
+
+// set-audio-level
+server.tool(
+  "set-audio-level",
+  "Set the audio level (dB) for an audio layer.",
+  {
+    compIndex: z.number().int().positive().describe("1-based index of the target composition."),
+    layerIndex: z.number().int().positive().describe("1-based index of the target layer."),
+    level: z.number().describe("Audio level in dB (e.g., 0 = unity, -6 = half volume, -96 = silence)."),
+    timeInSeconds: z.number().optional().describe("If provided, sets a keyframe at this time. Otherwise sets a constant value.")
+  },
+  async (params) => callBridge("setAudioLevel", params)
+);
+
+// enable-time-remap
+server.tool(
+  "enable-time-remap",
+  "Enable time remapping on a layer.",
+  {
+    compIndex: z.number().int().positive().describe("1-based index of the target composition."),
+    layerIndex: z.number().int().positive().describe("1-based index of the target layer.")
+  },
+  async (params) => callBridge("enableTimeRemap", params)
+);
+
+// set-time-remap-keyframe
+server.tool(
+  "set-time-remap-keyframe",
+  "Set a time remap keyframe on a layer.",
+  {
+    compIndex: z.number().int().positive().describe("1-based index of the target composition."),
+    layerIndex: z.number().int().positive().describe("1-based index of the target layer."),
+    timeInSeconds: z.number().describe("Timeline time in seconds for the keyframe."),
+    remapValue: z.number().describe("Source time value in seconds to remap to.")
+  },
+  async (params) => callBridge("setTimeRemapKeyframe", params)
+);
+
+// execute-script
+server.tool(
+  "execute-script",
+  "Execute arbitrary ExtendScript code in After Effects. Use with caution.",
+  {
+    script: z.string().describe("ExtendScript code to execute."),
+    description: z.string().optional().describe("Optional description of what the script does.")
+  },
+  async (params) => callBridge("executeScript", params)
+);
+
+// get-comp-frame
+server.tool(
+  "get-comp-frame",
+  "Save a frame from a composition as a PNG file and return its path.",
+  {
+    compIndex: z.number().int().positive().describe("1-based index of the target composition."),
+    timeInSeconds: z.number().describe("Time in seconds of the frame to capture."),
+    outputDir: z.string().optional().describe("Output directory for the frame. Defaults to ~/Documents/ae-mcp-bridge/frames/.")
+  },
+  async (params) => callBridge("getCompFrame", params, 30000)
+);
+
+// create-caption
+server.tool(
+  "create-caption",
+  "Create a styled caption text layer for subtitles or overlays.",
+  {
+    compIndex: z.number().int().positive().describe("1-based index of the target composition."),
+    text: z.string().describe("Caption text content."),
+    startTime: z.number().describe("Start time in seconds."),
+    endTime: z.number().describe("End time in seconds."),
+    style: z.enum(["lower-third","center","upper-third","custom"]).optional().describe("Caption position preset (default: lower-third)."),
+    fontSize: z.number().optional().describe("Font size in points (default: 36)."),
+    color: z.array(z.number()).optional().describe("Text color as [r,g,b] 0-1 (default: white)."),
+    backgroundColor: z.object({
+      r: z.number().optional(),
+      g: z.number().optional(),
+      b: z.number().optional(),
+      opacity: z.number().optional()
+    }).optional().describe("Optional background box color with opacity (0-100)."),
+    fontFamily: z.string().optional().describe("Font family name (default: Arial).")
+  },
+  async (params) => callBridge("createCaption", params)
+);
+
+// create-zoom-effect
+server.tool(
+  "create-zoom-effect",
+  "Add a zoom (scale) animation to a layer with keyframes and easing.",
+  {
+    compIndex: z.number().int().positive().describe("1-based index of the target composition."),
+    layerIndex: z.number().int().positive().describe("1-based index of the target layer."),
+    startTime: z.number().describe("Time in seconds to start the zoom."),
+    endTime: z.number().describe("Time in seconds to end the zoom."),
+    zoomFrom: z.number().optional().describe("Starting scale percentage (default: 100)."),
+    zoomTo: z.number().optional().describe("Ending scale percentage (default: 120)."),
+    easingType: z.enum(["linear","ease-in","ease-out","ease-in-out"]).optional().describe("Easing type for keyframes (default: ease-in-out)."),
+    anchorPoint: z.array(z.number()).optional().describe("Anchor point [x,y] for zoom origin.")
+  },
+  async (params) => callBridge("createZoomEffect", params)
+);
+
+// add-text-animator
+server.tool(
+  "add-text-animator",
+  "Add a text animator with range selector to a text layer.",
+  {
+    compIndex: z.number().int().positive().describe("1-based index of the target composition."),
+    layerIndex: z.number().int().positive().describe("1-based index of the target text layer."),
+    animatorType: z.enum(["opacity","position","scale","rotation","fill_color","character_offset","blur"]).describe("Type of property to animate per character."),
+    rangeStart: z.number().min(0).max(100).describe("Range selector start percentage (0-100)."),
+    rangeEnd: z.number().min(0).max(100).describe("Range selector end percentage (0-100)."),
+    value: z.any().describe("Value for the animator property.")
+  },
+  async (params) => callBridge("addTextAnimator", params)
+);
+
+// get-audio-waveform
+server.tool(
+  "get-audio-waveform",
+  "Get audio level data for a layer over a time range. Returns sampled audio levels.",
+  {
+    compIndex: z.number().int().positive().describe("1-based index of the target composition."),
+    layerIndex: z.number().int().positive().describe("1-based index of the target layer."),
+    startTime: z.number().describe("Start time in seconds."),
+    endTime: z.number().describe("End time in seconds."),
+    samples: z.number().int().positive().optional().describe("Number of sample points (default: 10).")
+  },
+  async (params) => callBridge("getAudioWaveform", params)
+);
+
+// align-layers
+server.tool(
+  "align-layers",
+  "Align multiple layers relative to each other or the composition.",
+  {
+    compIndex: z.number().int().positive().describe("1-based index of the target composition."),
+    layerIndices: z.array(z.number().int().positive()).describe("Array of 1-based layer indices to align."),
+    alignTo: z.enum(["left","right","top","bottom","horizontalCenter","verticalCenter","compLeft","compRight","compTop","compBottom","compHCenter","compVCenter"]).describe("Alignment target.")
+  },
+  async (params) => callBridge("alignLayers", params)
+);
+
+// distribute-keyframes
+server.tool(
+  "distribute-keyframes",
+  "Add multiple keyframes to a layer property at specified times.",
+  {
+    compIndex: z.number().int().positive().describe("1-based index of the target composition."),
+    layerIndex: z.number().int().positive().describe("1-based index of the target layer."),
+    propertyName: z.string().describe("Property name (e.g. 'Position', 'Scale', 'Opacity')."),
+    values: z.array(z.any()).describe("Array of values for each keyframe."),
+    times: z.array(z.number()).describe("Array of times in seconds for each keyframe."),
+    interpolationType: z.enum(["linear","hold","easy-ease"]).optional().describe("Interpolation type for keyframes (default: linear).")
+  },
+  async (params) => callBridge("distributeKeyframes", params)
+);
+
+// set-layer-stretch
+server.tool(
+  "set-layer-stretch",
+  "Set the time stretch percentage for a layer (50% = 2x speed, 200% = half speed).",
+  {
+    compIndex: z.number().int().positive().describe("1-based index of the target composition."),
+    layerIndex: z.number().int().positive().describe("1-based index of the target layer."),
+    stretch: z.number().describe("Stretch percentage (e.g., 50 = 2x speed, 200 = half speed, 100 = normal).")
+  },
+  async (params) => callBridge("setLayerStretch", params)
+);
+
+// duplicate-composition
+server.tool(
+  "duplicate-composition",
+  "Duplicate a composition in the project.",
+  {
+    compIndex: z.number().int().positive().describe("1-based index of the composition to duplicate."),
+    newName: z.string().optional().describe("Name for the duplicated composition (optional).")
+  },
+  async (params) => callBridge("duplicateComposition", params)
+);
+
+// get-renderer-info
+server.tool(
+  "get-renderer-info",
+  "Get information about available render engines for a composition.",
+  {
+    compIndex: z.number().int().positive().describe("1-based index of the target composition.")
+  },
+  async (params) => callBridge("getRendererInfo", params)
+);
+
+// set-renderer
+server.tool(
+  "set-renderer",
+  "Set the 3D renderer for a composition.",
+  {
+    compIndex: z.number().int().positive().describe("1-based index of the target composition."),
+    renderer: z.string().describe("Renderer match name: 'ADBE Advanced 3d' for C4D, 'ADBE Ernst' for Classic 3D.")
+  },
+  async (params) => callBridge("setRenderer", params)
+);
+
+// create-text-layer (wrapper with callBridge)
+server.tool(
+  "create-text-layer",
+  "Create a text layer in a composition.",
+  {
+    compName: z.string().describe("Name of the target composition."),
+    text: z.string().describe("Text content for the layer."),
+    position: z.array(z.number()).optional().describe("Position [x, y] in pixels (default: [960, 540])."),
+    fontSize: z.number().optional().describe("Font size in points (default: 72)."),
+    color: z.array(z.number()).optional().describe("Text color [r, g, b] 0-1 (default: white)."),
+    fontFamily: z.string().optional().describe("Font family name (default: Arial)."),
+    alignment: z.enum(["left","center","right"]).optional().describe("Text alignment (default: center)."),
+    startTime: z.number().optional().describe("Layer start time in seconds (default: 0)."),
+    duration: z.number().optional().describe("Layer duration in seconds (default: 5).")
+  },
+  async (params) => callBridge("createTextLayer", params)
+);
+
+// create-shape-layer (wrapper with callBridge)
+server.tool(
+  "create-shape-layer",
+  "Create a shape layer in a composition.",
+  {
+    compName: z.string().describe("Name of the target composition."),
+    shapeType: z.enum(["rectangle","ellipse","polygon","star"]).optional().describe("Shape type (default: rectangle)."),
+    position: z.array(z.number()).optional().describe("Position [x, y] in pixels."),
+    size: z.array(z.number()).optional().describe("Size [width, height] in pixels."),
+    fillColor: z.array(z.number()).optional().describe("Fill color [r, g, b] 0-1."),
+    strokeColor: z.array(z.number()).optional().describe("Stroke color [r, g, b] 0-1."),
+    strokeWidth: z.number().optional().describe("Stroke width in pixels (0 = no stroke)."),
+    startTime: z.number().optional().describe("Layer start time in seconds."),
+    duration: z.number().optional().describe("Layer duration in seconds."),
+    name: z.string().optional().describe("Layer name."),
+    points: z.number().optional().describe("Number of points for polygon/star shapes.")
+  },
+  async (params) => callBridge("createShapeLayer", params)
+);
+
+// create-solid-layer (wrapper with callBridge)
+server.tool(
+  "create-solid-layer",
+  "Create a solid or adjustment layer in a composition.",
+  {
+    compName: z.string().describe("Name of the target composition."),
+    color: z.array(z.number()).optional().describe("Solid color [r, g, b] 0-1 (default: white)."),
+    name: z.string().optional().describe("Layer name."),
+    position: z.array(z.number()).optional().describe("Position [x, y] in pixels."),
+    size: z.array(z.number()).optional().describe("Size [width, height] in pixels."),
+    startTime: z.number().optional().describe("Layer start time in seconds."),
+    duration: z.number().optional().describe("Layer duration in seconds."),
+    isAdjustment: z.boolean().optional().describe("Create as an adjustment layer (default: false).")
+  },
+  async (params) => callBridge("createSolidLayer", params)
+);
+
+// set-layer-properties (wrapper with callBridge)
+server.tool(
+  "set-layer-properties",
+  "Set transform properties and other attributes on a layer.",
+  {
+    compName: z.string().optional().describe("Name of the target composition."),
+    compIndex: z.number().int().positive().optional().describe("1-based index of the target composition."),
+    layerIndex: z.number().int().optional().describe("1-based index of the target layer."),
+    layerName: z.string().optional().describe("Name of the target layer."),
+    position: z.array(z.number()).optional().describe("Position [x, y] or [x, y, z] in pixels."),
+    scale: z.array(z.number()).optional().describe("Scale [x, y] or [x, y, z] in percent."),
+    rotation: z.number().optional().describe("Rotation in degrees."),
+    opacity: z.number().min(0).max(100).optional().describe("Opacity 0-100."),
+    startTime: z.number().optional().describe("Layer start time in seconds."),
+    duration: z.number().optional().describe("Layer duration in seconds."),
+    text: z.string().optional().describe("Text content (for text layers)."),
+    fontFamily: z.string().optional().describe("Font family (for text layers)."),
+    fontSize: z.number().optional().describe("Font size (for text layers)."),
+    fillColor: z.array(z.number()).optional().describe("Fill color [r,g,b] 0-1 (for text layers).")
+  },
+  async (params) => callBridge("setLayerProperties", params)
+);
+
+// add-lut-effect
+server.tool(
+  "add-lut-effect",
+  "Apply an Apply Color LUT effect to a layer using a .cube or .3dl LUT file.",
+  {
+    compIndex: z.number().int().positive().describe("1-based index of the target composition."),
+    layerIndex: z.number().int().positive().describe("1-based index of the target layer."),
+    lutPath: z.string().describe("Absolute path to the LUT file (.cube, .3dl, etc.).")
+  },
+  async (params) => callBridge("addLutEffect", params)
+);
+
+// create-slide-show
+server.tool(
+  "create-slide-show",
+  "Create a slideshow by importing images and arranging them as layers with transitions.",
+  {
+    compIndex: z.number().int().positive().describe("1-based index of the target composition."),
+    imagePaths: z.array(z.string()).describe("Array of absolute paths to image files."),
+    durationPerSlide: z.number().optional().describe("Duration per slide in seconds (default: 3)."),
+    transition: z.enum(["cut","fade","slide","zoom"]).optional().describe("Transition type between slides (default: cut)."),
+    transitionDuration: z.number().optional().describe("Duration of each transition in seconds (default: 0.5).")
+  },
+  async (params) => callBridge("createSlideShow", params)
 );
 
 // Start the MCP server
@@ -945,7 +1528,7 @@ async function main() {
   console.error("After Effects MCP Server starting...");
   console.error(`Scripts directory: ${SCRIPTS_DIR}`);
   console.error(`Temp directory: ${TEMP_DIR}`);
-  
+
   const transport = new StdioServerTransport();
   await server.connect(transport);
   console.error("After Effects MCP Server running...");

--- a/src/scripts/addLutEffect.jsx
+++ b/src/scripts/addLutEffect.jsx
@@ -1,0 +1,40 @@
+function addLutEffect(args) {
+    try {
+        var compIndex = args.compIndex || 1;
+        var layerIndex = args.layerIndex || 1;
+        var lutPath = args.lutPath;
+        if (!lutPath) throw new Error("lutPath is required");
+        var lutFile = new File(lutPath);
+        if (!lutFile.exists) throw new Error("LUT file not found: " + lutPath);
+        var comp = app.project.item(compIndex);
+        if (!(comp instanceof CompItem)) throw new Error("Item " + compIndex + " is not a composition");
+        var layer = comp.layer(layerIndex);
+        if (!layer) throw new Error("Layer not found at index " + layerIndex);
+        // Apply the "Apply Color LUT" effect
+        var effect = layer.property("Effects").addProperty("ADBE Apply Color LUT2");
+        if (!effect) {
+            // Fallback to older name
+            effect = layer.property("Effects").addProperty("ADBE Apply Color LUT");
+        }
+        if (!effect) throw new Error("Could not add Apply Color LUT effect. Ensure it is available in your AE installation.");
+        // Set the LUT file
+        var lutFileProp = effect.property("LUT");
+        if (!lutFileProp) {
+            // Try alternate property names
+            for (var i = 1; i <= effect.numProperties; i++) {
+                var p = effect.property(i);
+                if (p.name.toLowerCase().indexOf("lut") !== -1 || p.name.toLowerCase().indexOf("cube") !== -1) {
+                    lutFileProp = p;
+                    break;
+                }
+            }
+        }
+        if (lutFileProp) {
+            lutFileProp.setValue(lutFile);
+        }
+        return JSON.stringify({
+            status: "success", message: "LUT effect applied: " + lutPath,
+            effect: { name: effect.name, matchName: effect.matchName }, lutPath: lutPath
+        }, null, 2);
+    } catch (e) { return JSON.stringify({ status: "error", message: e.toString() }, null, 2); }
+}

--- a/src/scripts/addMarker.jsx
+++ b/src/scripts/addMarker.jsx
@@ -1,0 +1,25 @@
+function addMarker(args) {
+    try {
+        var compIndex = args.compIndex || 1;
+        var layerIndex = args.layerIndex;
+        var time = args.time !== undefined ? args.time : 0;
+        var label = args.label || "";
+        var comment = args.comment || "";
+        var duration = args.duration || 0;
+        var url = args.url || "";
+        var comp = app.project.item(compIndex);
+        if (!(comp instanceof CompItem)) throw new Error("Item " + compIndex + " is not a composition");
+        var mv = new MarkerValue(comment);
+        if (duration > 0) mv.duration = duration;
+        if (url) mv.url = url;
+        if (layerIndex && layerIndex > 0) {
+            var layer = comp.layer(layerIndex);
+            if (!layer) throw new Error("Layer not found at index " + layerIndex);
+            layer.property("Marker").setValueAtTime(time, mv);
+            return JSON.stringify({ status: "success", message: "Layer marker added at time " + time, markerType: "layer", time: time, comment: comment }, null, 2);
+        } else {
+            comp.markerProperty.setValueAtTime(time, mv);
+            return JSON.stringify({ status: "success", message: "Composition marker added at time " + time, markerType: "composition", time: time, comment: comment }, null, 2);
+        }
+    } catch (e) { return JSON.stringify({ status: "error", message: e.toString() }, null, 2); }
+}

--- a/src/scripts/addMask.jsx
+++ b/src/scripts/addMask.jsx
@@ -1,0 +1,59 @@
+function addMask(args) {
+    try {
+        var compIndex = args.compIndex || 1;
+        var layerIndex = args.layerIndex || 1;
+        var maskShape = args.maskShape || "rectangle";
+        var vertices = args.vertices || [];
+        var inverted = args.inverted !== undefined ? args.inverted : false;
+        var comp = app.project.item(compIndex);
+        if (!(comp instanceof CompItem)) throw new Error("Item " + compIndex + " is not a composition");
+        var layer = comp.layer(layerIndex);
+        if (!layer) throw new Error("Layer not found at index " + layerIndex);
+        var maskGroup = layer.property("Masks");
+        var mask = maskGroup.addProperty("Mask");
+        mask.inverted = inverted;
+        var maskPath = mask.property("Mask Path");
+        var shape = new Shape();
+        var w = comp.width;
+        var h = comp.height;
+        if (maskShape === "rectangle") {
+            shape.vertices = [[0, 0], [w, 0], [w, h], [0, h]];
+            shape.inTangents = [[0, 0], [0, 0], [0, 0], [0, 0]];
+            shape.outTangents = [[0, 0], [0, 0], [0, 0], [0, 0]];
+            shape.closed = true;
+        } else if (maskShape === "ellipse") {
+            var cx = w / 2;
+            var cy = h / 2;
+            var rx = w / 2;
+            var ry = h / 2;
+            var k = 0.5522847498;
+            shape.vertices = [[cx, cy - ry], [cx + rx, cy], [cx, cy + ry], [cx - rx, cy]];
+            shape.inTangents = [[-k * rx, 0], [0, -k * ry], [k * rx, 0], [0, k * ry]];
+            shape.outTangents = [[k * rx, 0], [0, k * ry], [-k * rx, 0], [0, -k * ry]];
+            shape.closed = true;
+        } else if (maskShape === "freeform" && vertices.length >= 3) {
+            var verts = [];
+            var inTans = [];
+            var outTans = [];
+            for (var i = 0; i < vertices.length; i++) {
+                verts.push([vertices[i][0], vertices[i][1]]);
+                inTans.push([0, 0]);
+                outTans.push([0, 0]);
+            }
+            shape.vertices = verts;
+            shape.inTangents = inTans;
+            shape.outTangents = outTans;
+            shape.closed = true;
+        } else {
+            shape.vertices = [[0, 0], [w, 0], [w, h], [0, h]];
+            shape.inTangents = [[0, 0], [0, 0], [0, 0], [0, 0]];
+            shape.outTangents = [[0, 0], [0, 0], [0, 0], [0, 0]];
+            shape.closed = true;
+        }
+        maskPath.setValue(shape);
+        return JSON.stringify({
+            status: "success", message: "Mask added",
+            mask: { index: mask.propertyIndex, inverted: inverted, shape: maskShape }
+        }, null, 2);
+    } catch (e) { return JSON.stringify({ status: "error", message: e.toString() }, null, 2); }
+}

--- a/src/scripts/addTextAnimator.jsx
+++ b/src/scripts/addTextAnimator.jsx
@@ -1,0 +1,50 @@
+function addTextAnimator(args) {
+    try {
+        var compIndex = args.compIndex || 1;
+        var layerIndex = args.layerIndex || 1;
+        var animatorType = args.animatorType || "opacity";
+        var rangeStart = args.rangeStart !== undefined ? args.rangeStart : 0;
+        var rangeEnd = args.rangeEnd !== undefined ? args.rangeEnd : 100;
+        var value = args.value;
+        var comp = app.project.item(compIndex);
+        if (!(comp instanceof CompItem)) throw new Error("Item " + compIndex + " is not a composition");
+        var layer = comp.layer(layerIndex);
+        if (!layer) throw new Error("Layer not found at index " + layerIndex);
+        if (!(layer instanceof TextLayer)) throw new Error("Layer is not a text layer");
+        var textProps = layer.property("Text");
+        var animators = textProps.property("Animators");
+        var animator = animators.addProperty("ADBE Text Animator");
+        // Add range selector
+        var selectors = animator.property("Selector");
+        if (!selectors || selectors.numProperties === 0) {
+            animator.property("Selector").addProperty("ADBE Text Selector");
+        }
+        var selector = animator.property("Selector").property(1);
+        if (selector) {
+            var startProp = selector.property("Start");
+            var endProp = selector.property("End");
+            if (startProp) startProp.setValue(rangeStart);
+            if (endProp) endProp.setValue(rangeEnd);
+        }
+        // Add animator property based on type
+        var animProps = animator.property("Animator Properties");
+        var typeMap = {
+            "opacity": "ADBE Text Opacity",
+            "position": "ADBE Text Position",
+            "scale": "ADBE Text Scale",
+            "rotation": "ADBE Text Rotation",
+            "fill_color": "ADBE Text Fill Color",
+            "character_offset": "ADBE Text Character Change Type",
+            "blur": "ADBE Text Blur"
+        };
+        var propMatchName = typeMap[animatorType.toLowerCase()] || "ADBE Text Opacity";
+        var animProp = animProps.addProperty(propMatchName);
+        if (animProp && value !== undefined) {
+            try { animProp.setValue(value); } catch (e) { /* value may not be directly settable */ }
+        }
+        return JSON.stringify({
+            status: "success", message: "Text animator added: " + animatorType,
+            animator: { type: animatorType, rangeStart: rangeStart, rangeEnd: rangeEnd, value: value }
+        }, null, 2);
+    } catch (e) { return JSON.stringify({ status: "error", message: e.toString() }, null, 2); }
+}

--- a/src/scripts/addToRenderQueue.jsx
+++ b/src/scripts/addToRenderQueue.jsx
@@ -1,0 +1,20 @@
+function addToRenderQueue(args) {
+    try {
+        var compIndex = args.compIndex || 1;
+        var outputPath = args.outputPath;
+        var outputModuleTemplate = args.outputModuleTemplate || "Lossless";
+        var renderSettingsTemplate = args.renderSettingsTemplate || "Best Settings";
+        if (!outputPath) throw new Error("outputPath is required");
+        var comp = app.project.item(compIndex);
+        if (!(comp instanceof CompItem)) throw new Error("Item " + compIndex + " is not a composition");
+        var rqItem = app.project.renderQueue.items.add(comp);
+        try { rqItem.applyTemplate(renderSettingsTemplate); } catch (e) { /* use defaults if template not found */ }
+        var om = rqItem.outputModule(1);
+        try { om.applyTemplate(outputModuleTemplate); } catch (e) { /* use defaults if template not found */ }
+        om.file = new File(outputPath);
+        return JSON.stringify({
+            status: "success", message: "Added to render queue",
+            renderQueueItem: { index: rqItem.index, outputPath: outputPath, comp: comp.name }
+        }, null, 2);
+    } catch (e) { return JSON.stringify({ status: "error", message: e.toString() }, null, 2); }
+}

--- a/src/scripts/alignLayers.jsx
+++ b/src/scripts/alignLayers.jsx
@@ -1,0 +1,45 @@
+function alignLayers(args) {
+    try {
+        var compIndex = args.compIndex || 1;
+        var layerIndices = args.layerIndices || [];
+        var alignTo = args.alignTo || "compHCenter";
+        if (layerIndices.length === 0) throw new Error("layerIndices array is required and must not be empty");
+        var comp = app.project.item(compIndex);
+        if (!(comp instanceof CompItem)) throw new Error("Item " + compIndex + " is not a composition");
+        var layers = [];
+        for (var i = 0; i < layerIndices.length; i++) {
+            var layer = comp.layer(layerIndices[i]);
+            if (!layer) throw new Error("Layer not found at index " + layerIndices[i]);
+            layers.push(layer);
+        }
+        var compW = comp.width;
+        var compH = comp.height;
+        // Get bounding info from first layer for relative alignments
+        var refPos = layers[0].property("Position").value;
+        var changed = [];
+        for (var j = 0; j < layers.length; j++) {
+            var pos = layers[j].property("Position").value;
+            var newX = pos[0];
+            var newY = pos[1];
+            if (alignTo === "compLeft") { newX = 0; }
+            else if (alignTo === "compRight") { newX = compW; }
+            else if (alignTo === "compTop") { newY = 0; }
+            else if (alignTo === "compBottom") { newY = compH; }
+            else if (alignTo === "compHCenter") { newX = compW / 2; }
+            else if (alignTo === "compVCenter") { newY = compH / 2; }
+            else if (alignTo === "left") { newX = refPos[0]; }
+            else if (alignTo === "right") { newX = refPos[0]; }
+            else if (alignTo === "top") { newY = refPos[1]; }
+            else if (alignTo === "bottom") { newY = refPos[1]; }
+            else if (alignTo === "horizontalCenter") { newX = refPos[0]; }
+            else if (alignTo === "verticalCenter") { newY = refPos[1]; }
+            var newPos = pos.length === 3 ? [newX, newY, pos[2]] : [newX, newY];
+            layers[j].property("Position").setValue(newPos);
+            changed.push({ name: layers[j].name, index: layers[j].index, newPosition: newPos });
+        }
+        return JSON.stringify({
+            status: "success", message: "Layers aligned to " + alignTo,
+            alignedLayers: changed
+        }, null, 2);
+    } catch (e) { return JSON.stringify({ status: "error", message: e.toString() }, null, 2); }
+}

--- a/src/scripts/createCamera.jsx
+++ b/src/scripts/createCamera.jsx
@@ -1,0 +1,28 @@
+function createCamera(args) {
+    try {
+        var compIndex = args.compIndex || 1;
+        var name = args.name || "Camera 1";
+        var preset = args.preset || "50mm";
+        var zoom = args.zoom;
+        var filmSize = args.filmSize || 36;
+        var comp = app.project.item(compIndex);
+        if (!(comp instanceof CompItem)) throw new Error("Item " + compIndex + " is not a composition");
+        var centerX = comp.width / 2;
+        var centerY = comp.height / 2;
+        var cameraLayer = comp.layers.addCamera(name, [centerX, centerY]);
+        // Set zoom based on preset or explicit zoom
+        if (!zoom) {
+            var presetZooms = { "15mm": 135, "20mm": 181, "24mm": 216, "28mm": 252, "35mm": 315, "50mm": 450, "80mm": 720, "85mm": 765, "135mm": 1215, "200mm": 1800 };
+            zoom = presetZooms[preset] || 450;
+        }
+        var cameraOptions = cameraLayer.property("Camera Options");
+        if (cameraOptions) {
+            var zoomProp = cameraOptions.property("Zoom");
+            if (zoomProp) zoomProp.setValue(zoom);
+        }
+        return JSON.stringify({
+            status: "success", message: "Camera layer created",
+            layer: { name: cameraLayer.name, index: cameraLayer.index, preset: preset, zoom: zoom, filmSize: filmSize }
+        }, null, 2);
+    } catch (e) { return JSON.stringify({ status: "error", message: e.toString() }, null, 2); }
+}

--- a/src/scripts/createCaption.jsx
+++ b/src/scripts/createCaption.jsx
@@ -1,0 +1,55 @@
+function createCaption(args) {
+    try {
+        var compIndex = args.compIndex || 1;
+        var text = args.text || "Caption";
+        var startTime = args.startTime !== undefined ? args.startTime : 0;
+        var endTime = args.endTime !== undefined ? args.endTime : startTime + 3;
+        var style = args.style || "lower-third";
+        var fontSize = args.fontSize || 36;
+        var color = args.color || [1, 1, 1];
+        var fontFamily = args.fontFamily || "Arial";
+        var backgroundColor = args.backgroundColor;
+        var comp = app.project.item(compIndex);
+        if (!(comp instanceof CompItem)) throw new Error("Item " + compIndex + " is not a composition");
+        // Calculate position based on style
+        var posX = comp.width / 2;
+        var posY;
+        if (style === "lower-third") {
+            posY = comp.height * 0.8;
+        } else if (style === "upper-third") {
+            posY = comp.height * 0.15;
+        } else if (style === "center") {
+            posY = comp.height / 2;
+        } else {
+            posY = comp.height * 0.8;
+        }
+        // Add background solid if backgroundColor provided
+        if (backgroundColor) {
+            var bgColor = [backgroundColor.r || 0, backgroundColor.g || 0, backgroundColor.b || 0];
+            var bgOpacity = backgroundColor.opacity !== undefined ? backgroundColor.opacity : 70;
+            var bgWidth = comp.width;
+            var bgHeight = Math.round(fontSize * 2);
+            var bgSolid = comp.layers.addSolid(bgColor, "Caption BG", bgWidth, bgHeight, 1);
+            bgSolid.property("Position").setValue([posX, posY]);
+            bgSolid.startTime = startTime;
+            bgSolid.outPoint = endTime;
+            bgSolid.property("Opacity").setValue(bgOpacity);
+        }
+        var textLayer = comp.layers.addText(text);
+        var textProp = textLayer.property("ADBE Text Properties").property("ADBE Text Document");
+        var textDocument = textProp.value;
+        textDocument.fontSize = fontSize;
+        textDocument.fillColor = color;
+        textDocument.font = fontFamily;
+        textDocument.justification = ParagraphJustification.CENTER_JUSTIFY;
+        textProp.setValue(textDocument);
+        textLayer.property("Position").setValue([posX, posY]);
+        textLayer.startTime = startTime;
+        textLayer.outPoint = endTime;
+        textLayer.name = "Caption: " + text.substring(0, 20);
+        return JSON.stringify({
+            status: "success", message: "Caption created",
+            layer: { name: textLayer.name, index: textLayer.index, position: [posX, posY], startTime: startTime, endTime: endTime, style: style }
+        }, null, 2);
+    } catch (e) { return JSON.stringify({ status: "error", message: e.toString() }, null, 2); }
+}

--- a/src/scripts/createLight.jsx
+++ b/src/scripts/createLight.jsx
@@ -1,0 +1,45 @@
+function createLight(args) {
+    try {
+        var compIndex = args.compIndex || 1;
+        var name = args.name || "Light 1";
+        var lightTypeStr = args.lightType || "POINT";
+        var color = args.color || [1, 1, 1];
+        var intensity = args.intensity !== undefined ? args.intensity : 100;
+        var castsShadows = args.castsShadows !== undefined ? args.castsShadows : false;
+        var coneAngle = args.coneAngle || 90;
+        var coneFeather = args.coneFeather || 50;
+        var comp = app.project.item(compIndex);
+        if (!(comp instanceof CompItem)) throw new Error("Item " + compIndex + " is not a composition");
+        var centerX = comp.width / 2;
+        var centerY = comp.height / 2;
+        var lightLayer = comp.layers.addLight(name, [centerX, centerY]);
+        var lightOptions = lightLayer.property("Light Options");
+        if (lightOptions) {
+            var lightTypeMap = {
+                "PARALLEL": LightType.PARALLEL,
+                "SPOT": LightType.SPOT,
+                "POINT": LightType.POINT,
+                "AMBIENT": LightType.AMBIENT
+            };
+            var ltType = lightTypeMap[lightTypeStr.toUpperCase()] || LightType.POINT;
+            var ltProp = lightOptions.property("Light Type");
+            if (ltProp) ltProp.setValue(ltType);
+            var colorProp = lightOptions.property("Color");
+            if (colorProp) colorProp.setValue(color);
+            var intensityProp = lightOptions.property("Intensity");
+            if (intensityProp) intensityProp.setValue(intensity);
+            var shadowsProp = lightOptions.property("Casts Shadows");
+            if (shadowsProp) shadowsProp.setValue(castsShadows ? 1 : 0);
+            if (lightTypeStr.toUpperCase() === "SPOT") {
+                var coneAngleProp = lightOptions.property("Cone Angle");
+                if (coneAngleProp) coneAngleProp.setValue(coneAngle);
+                var coneFeatherProp = lightOptions.property("Cone Feather");
+                if (coneFeatherProp) coneFeatherProp.setValue(coneFeather);
+            }
+        }
+        return JSON.stringify({
+            status: "success", message: "Light layer created",
+            layer: { name: lightLayer.name, index: lightLayer.index, lightType: lightTypeStr, color: color, intensity: intensity, castsShadows: castsShadows }
+        }, null, 2);
+    } catch (e) { return JSON.stringify({ status: "error", message: e.toString() }, null, 2); }
+}

--- a/src/scripts/createNullObject.jsx
+++ b/src/scripts/createNullObject.jsx
@@ -1,0 +1,17 @@
+function createNullObject(args) {
+    try {
+        var compIndex = args.compIndex || 1;
+        var name = args.name || "Null";
+        var startTime = args.startTime || 0;
+        var duration = args.duration || 0;
+        var comp = app.project.item(compIndex);
+        if (!(comp instanceof CompItem)) throw new Error("Item " + compIndex + " is not a composition");
+        var nullLayer = comp.layers.addNull(duration || comp.duration);
+        nullLayer.name = name;
+        nullLayer.startTime = startTime;
+        return JSON.stringify({
+            status: "success", message: "Null object created",
+            layer: { name: nullLayer.name, index: nullLayer.index, inPoint: nullLayer.inPoint, outPoint: nullLayer.outPoint }
+        }, null, 2);
+    } catch (e) { return JSON.stringify({ status: "error", message: e.toString() }, null, 2); }
+}

--- a/src/scripts/createSlideShow.jsx
+++ b/src/scripts/createSlideShow.jsx
@@ -1,0 +1,47 @@
+function createSlideShow(args) {
+    try {
+        var compIndex = args.compIndex || 1;
+        var imagePaths = args.imagePaths || [];
+        var durationPerSlide = args.durationPerSlide !== undefined ? args.durationPerSlide : 3;
+        var transition = args.transition || "cut";
+        var transitionDuration = args.transitionDuration !== undefined ? args.transitionDuration : 0.5;
+        if (imagePaths.length === 0) throw new Error("imagePaths is required and must not be empty");
+        var comp = app.project.item(compIndex);
+        if (!(comp instanceof CompItem)) throw new Error("Item " + compIndex + " is not a composition");
+        var layers = [];
+        for (var i = 0; i < imagePaths.length; i++) {
+            var file = new File(imagePaths[i]);
+            if (!file.exists) { throw new Error("Image file not found: " + imagePaths[i]); }
+            var importOptions = new ImportOptions(file);
+            var footageItem = app.project.importFile(importOptions);
+            var slideStart = i * durationPerSlide;
+            var slideEnd = slideStart + durationPerSlide;
+            var footageLayer = comp.layers.add(footageItem);
+            footageLayer.startTime = slideStart;
+            footageLayer.outPoint = slideEnd;
+            // Scale to fit comp
+            var scaleX = (comp.width / footageLayer.width) * 100;
+            var scaleY = (comp.height / footageLayer.height) * 100;
+            var scale = Math.min(scaleX, scaleY);
+            footageLayer.property("Scale").setValue([scale, scale]);
+            footageLayer.property("Position").setValue([comp.width / 2, comp.height / 2]);
+            // Apply transitions
+            if (transition === "fade" && i > 0) {
+                var opacityProp = footageLayer.property("Opacity");
+                opacityProp.setValueAtTime(slideStart, 0);
+                opacityProp.setValueAtTime(slideStart + transitionDuration, 100);
+                opacityProp.setValueAtTime(slideEnd - transitionDuration, 100);
+                opacityProp.setValueAtTime(slideEnd, 0);
+            } else if (transition === "zoom") {
+                var scaleProp = footageLayer.property("Scale");
+                scaleProp.setValueAtTime(slideStart, [scale * 0.9, scale * 0.9]);
+                scaleProp.setValueAtTime(slideEnd, [scale * 1.1, scale * 1.1]);
+            }
+            layers.push({ name: footageLayer.name, index: footageLayer.index, start: slideStart, end: slideEnd });
+        }
+        return JSON.stringify({
+            status: "success", message: "Slideshow created with " + layers.length + " slides",
+            totalDuration: imagePaths.length * durationPerSlide, transition: transition, layers: layers
+        }, null, 2);
+    } catch (e) { return JSON.stringify({ status: "error", message: e.toString() }, null, 2); }
+}

--- a/src/scripts/createZoomEffect.jsx
+++ b/src/scripts/createZoomEffect.jsx
@@ -1,0 +1,49 @@
+function createZoomEffect(args) {
+    try {
+        var compIndex = args.compIndex || 1;
+        var layerIndex = args.layerIndex || 1;
+        var startTime = args.startTime !== undefined ? args.startTime : 0;
+        var endTime = args.endTime !== undefined ? args.endTime : 1;
+        var zoomFrom = args.zoomFrom !== undefined ? args.zoomFrom : 100;
+        var zoomTo = args.zoomTo !== undefined ? args.zoomTo : 120;
+        var easingType = args.easingType || "ease-in-out";
+        var anchorPoint = args.anchorPoint;
+        var comp = app.project.item(compIndex);
+        if (!(comp instanceof CompItem)) throw new Error("Item " + compIndex + " is not a composition");
+        var layer = comp.layer(layerIndex);
+        if (!layer) throw new Error("Layer not found at index " + layerIndex);
+        var scaleProp = layer.property("Transform").property("Scale");
+        if (!scaleProp) throw new Error("Scale property not found");
+        // Set anchor point if specified
+        if (anchorPoint) {
+            var apProp = layer.property("Transform").property("Anchor Point");
+            if (apProp) apProp.setValue(anchorPoint);
+        }
+        // Set scale keyframes
+        scaleProp.setValueAtTime(startTime, [zoomFrom, zoomFrom]);
+        scaleProp.setValueAtTime(endTime, [zoomTo, zoomTo]);
+        // Apply easing
+        var numKeys = scaleProp.numKeys;
+        if (numKeys >= 2) {
+            var easeIn, easeOut;
+            if (easingType === "ease-in-out") {
+                easeIn = [new KeyframeEase(33, 33)];
+                easeOut = [new KeyframeEase(33, 33)];
+                scaleProp.setTemporalEaseAtKey(numKeys - 1, easeIn, easeOut);
+                scaleProp.setTemporalEaseAtKey(numKeys, easeIn, easeOut);
+            } else if (easingType === "ease-in") {
+                easeIn = [new KeyframeEase(0, 33)];
+                easeOut = [new KeyframeEase(33, 33)];
+                scaleProp.setTemporalEaseAtKey(numKeys - 1, easeIn, easeOut);
+            } else if (easingType === "ease-out") {
+                easeIn = [new KeyframeEase(33, 33)];
+                easeOut = [new KeyframeEase(33, 0)];
+                scaleProp.setTemporalEaseAtKey(numKeys, easeIn, easeOut);
+            }
+        }
+        return JSON.stringify({
+            status: "success", message: "Zoom effect created from " + zoomFrom + "% to " + zoomTo + "%",
+            layer: { name: layer.name, index: layer.index, zoomFrom: zoomFrom, zoomTo: zoomTo, startTime: startTime, endTime: endTime, easingType: easingType }
+        }, null, 2);
+    } catch (e) { return JSON.stringify({ status: "error", message: e.toString() }, null, 2); }
+}

--- a/src/scripts/deleteLayer.jsx
+++ b/src/scripts/deleteLayer.jsx
@@ -1,0 +1,13 @@
+function deleteLayer(args) {
+    try {
+        var compIndex = args.compIndex || 1;
+        var layerIndex = args.layerIndex || 1;
+        var comp = app.project.item(compIndex);
+        if (!(comp instanceof CompItem)) throw new Error("Item " + compIndex + " is not a composition");
+        var layer = comp.layer(layerIndex);
+        if (!layer) throw new Error("Layer not found at index " + layerIndex);
+        var layerName = layer.name;
+        layer.remove();
+        return JSON.stringify({ status: "success", message: "Layer deleted: " + layerName, layerName: layerName }, null, 2);
+    } catch (e) { return JSON.stringify({ status: "error", message: e.toString() }, null, 2); }
+}

--- a/src/scripts/deleteMask.jsx
+++ b/src/scripts/deleteMask.jsx
@@ -1,0 +1,16 @@
+function deleteMask(args) {
+    try {
+        var compIndex = args.compIndex || 1;
+        var layerIndex = args.layerIndex || 1;
+        var maskIndex = args.maskIndex || 1;
+        var comp = app.project.item(compIndex);
+        if (!(comp instanceof CompItem)) throw new Error("Item " + compIndex + " is not a composition");
+        var layer = comp.layer(layerIndex);
+        if (!layer) throw new Error("Layer not found at index " + layerIndex);
+        var maskGroup = layer.property("Masks");
+        var mask = maskGroup.property(maskIndex);
+        if (!mask) throw new Error("Mask not found at index " + maskIndex);
+        mask.remove();
+        return JSON.stringify({ status: "success", message: "Mask " + maskIndex + " deleted" }, null, 2);
+    } catch (e) { return JSON.stringify({ status: "error", message: e.toString() }, null, 2); }
+}

--- a/src/scripts/distributeKeyframes.jsx
+++ b/src/scripts/distributeKeyframes.jsx
@@ -1,0 +1,51 @@
+function distributeKeyframes(args) {
+    try {
+        var compIndex = args.compIndex || 1;
+        var layerIndex = args.layerIndex || 1;
+        var propertyName = args.propertyName;
+        var values = args.values || [];
+        var times = args.times || [];
+        var interpolationType = args.interpolationType || "linear";
+        if (!propertyName) throw new Error("propertyName is required");
+        if (values.length === 0) throw new Error("values array is required");
+        if (times.length === 0) throw new Error("times array is required");
+        if (values.length !== times.length) throw new Error("values and times arrays must have the same length");
+        var comp = app.project.item(compIndex);
+        if (!(comp instanceof CompItem)) throw new Error("Item " + compIndex + " is not a composition");
+        var layer = comp.layer(layerIndex);
+        if (!layer) throw new Error("Layer not found at index " + layerIndex);
+        // Try to find property in Transform group or directly
+        var prop = null;
+        var transform = layer.property("Transform");
+        if (transform) {
+            try { prop = transform.property(propertyName); } catch (e) { prop = null; }
+        }
+        if (!prop) {
+            try { prop = layer.property(propertyName); } catch (e) { prop = null; }
+        }
+        if (!prop) throw new Error("Property not found: " + propertyName);
+        var addedKeys = [];
+        for (var i = 0; i < times.length; i++) {
+            prop.setValueAtTime(times[i], values[i]);
+            addedKeys.push({ time: times[i], value: values[i] });
+        }
+        // Apply interpolation type
+        if (interpolationType === "hold") {
+            for (var k = 1; k <= prop.numKeys; k++) {
+                try { prop.setInterpolationTypeAtKey(k, KeyframeInterpolationType.HOLD); } catch (e) { /* ignore */ }
+            }
+        } else if (interpolationType === "easy-ease") {
+            for (var k2 = 1; k2 <= prop.numKeys; k2++) {
+                try {
+                    var ease = [new KeyframeEase(33, 33)];
+                    prop.setTemporalEaseAtKey(k2, ease, ease);
+                } catch (e) { /* ignore */ }
+            }
+        }
+        // Linear is the default, no action needed
+        return JSON.stringify({
+            status: "success", message: "Added " + addedKeys.length + " keyframes to " + propertyName,
+            propertyName: propertyName, keyframes: addedKeys, interpolationType: interpolationType
+        }, null, 2);
+    } catch (e) { return JSON.stringify({ status: "error", message: e.toString() }, null, 2); }
+}

--- a/src/scripts/duplicateComposition.jsx
+++ b/src/scripts/duplicateComposition.jsx
@@ -1,0 +1,14 @@
+function duplicateComposition(args) {
+    try {
+        var compIndex = args.compIndex || 1;
+        var newName = args.newName;
+        var comp = app.project.item(compIndex);
+        if (!(comp instanceof CompItem)) throw new Error("Item " + compIndex + " is not a composition");
+        var newComp = comp.duplicate();
+        if (newName) newComp.name = newName;
+        return JSON.stringify({
+            status: "success", message: "Composition duplicated",
+            newComp: { name: newComp.name, id: newComp.id, width: newComp.width, height: newComp.height, duration: newComp.duration, frameRate: newComp.frameRate, numLayers: newComp.numLayers }
+        }, null, 2);
+    } catch (e) { return JSON.stringify({ status: "error", message: e.toString() }, null, 2); }
+}

--- a/src/scripts/duplicateLayer.jsx
+++ b/src/scripts/duplicateLayer.jsx
@@ -1,0 +1,15 @@
+function duplicateLayer(args) {
+    try {
+        var compIndex = args.compIndex || 1;
+        var layerIndex = args.layerIndex || 1;
+        var comp = app.project.item(compIndex);
+        if (!(comp instanceof CompItem)) throw new Error("Item " + compIndex + " is not a composition");
+        var layer = comp.layer(layerIndex);
+        if (!layer) throw new Error("Layer not found at index " + layerIndex);
+        var newLayer = layer.duplicate();
+        return JSON.stringify({
+            status: "success", message: "Layer duplicated",
+            layer: { name: newLayer.name, index: newLayer.index, inPoint: newLayer.inPoint, outPoint: newLayer.outPoint }
+        }, null, 2);
+    } catch (e) { return JSON.stringify({ status: "error", message: e.toString() }, null, 2); }
+}

--- a/src/scripts/enableTimeRemap.jsx
+++ b/src/scripts/enableTimeRemap.jsx
@@ -1,0 +1,15 @@
+function enableTimeRemap(args) {
+    try {
+        var compIndex = args.compIndex || 1;
+        var layerIndex = args.layerIndex || 1;
+        var comp = app.project.item(compIndex);
+        if (!(comp instanceof CompItem)) throw new Error("Item " + compIndex + " is not a composition");
+        var layer = comp.layer(layerIndex);
+        if (!layer) throw new Error("Layer not found at index " + layerIndex);
+        layer.timeRemapEnabled = true;
+        return JSON.stringify({
+            status: "success", message: "Time remap enabled",
+            layer: { name: layer.name, index: layer.index, timeRemapEnabled: layer.timeRemapEnabled }
+        }, null, 2);
+    } catch (e) { return JSON.stringify({ status: "error", message: e.toString() }, null, 2); }
+}

--- a/src/scripts/executeScript.jsx
+++ b/src/scripts/executeScript.jsx
@@ -1,0 +1,21 @@
+function executeScript(args) {
+    try {
+        var script = args.script;
+        if (!script) throw new Error("script is required");
+        var result;
+        try {
+            result = eval(script);
+        } catch (evalErr) {
+            return JSON.stringify({ status: "error", message: "Script execution error: " + evalErr.toString(), script: script }, null, 2);
+        }
+        var resultStr;
+        if (result === undefined || result === null) {
+            resultStr = String(result);
+        } else if (typeof result === "object") {
+            try { resultStr = JSON.stringify(result); } catch (e) { resultStr = result.toString(); }
+        } else {
+            resultStr = String(result);
+        }
+        return JSON.stringify({ status: "success", message: "Script executed successfully", result: resultStr }, null, 2);
+    } catch (e) { return JSON.stringify({ status: "error", message: e.toString() }, null, 2); }
+}

--- a/src/scripts/exportFrame.jsx
+++ b/src/scripts/exportFrame.jsx
@@ -1,0 +1,26 @@
+function exportFrame(args) {
+    try {
+        var compIndex = args.compIndex || 1;
+        var timeInSeconds = args.timeInSeconds !== undefined ? args.timeInSeconds : 0;
+        var outputPath = args.outputPath;
+        if (!outputPath) throw new Error("outputPath is required");
+        var comp = app.project.item(compIndex);
+        if (!(comp instanceof CompItem)) throw new Error("Item " + compIndex + " is not a composition");
+        var rqItem = app.project.renderQueue.items.add(comp);
+        rqItem.timeSpanStart = timeInSeconds;
+        rqItem.timeSpanDuration = 1 / comp.frameRate;
+        var om = rqItem.outputModule(1);
+        om.file = new File(outputPath);
+        try { om.format = "PNG"; } catch (e) { /* format may already be set */ }
+        // Apply PNG output module settings
+        try {
+            om.applyTemplate("PNG Sequence");
+        } catch (e) {
+            // ignore if template not available
+        }
+        om.file = new File(outputPath);
+        app.project.renderQueue.render();
+        rqItem.remove();
+        return JSON.stringify({ status: "success", message: "Frame exported to " + outputPath, outputPath: outputPath, time: timeInSeconds }, null, 2);
+    } catch (e) { return JSON.stringify({ status: "error", message: e.toString() }, null, 2); }
+}

--- a/src/scripts/getAudioWaveform.jsx
+++ b/src/scripts/getAudioWaveform.jsx
@@ -1,0 +1,54 @@
+function getAudioWaveform(args) {
+    try {
+        var compIndex = args.compIndex || 1;
+        var layerIndex = args.layerIndex || 1;
+        var startTime = args.startTime !== undefined ? args.startTime : 0;
+        var endTime = args.endTime !== undefined ? args.endTime : 1;
+        var samples = args.samples || 10;
+        var comp = app.project.item(compIndex);
+        if (!(comp instanceof CompItem)) throw new Error("Item " + compIndex + " is not a composition");
+        var layer = comp.layer(layerIndex);
+        if (!layer) throw new Error("Layer not found at index " + layerIndex);
+        // ExtendScript does not provide direct audio sample data.
+        // We can approximate by sampling the Audio Levels property over time.
+        var audio = layer.property("Audio");
+        var levelData = [];
+        var duration = endTime - startTime;
+        var step = duration / samples;
+        if (audio) {
+            var audioLevels = audio.property("Audio Levels");
+            if (audioLevels) {
+                for (var i = 0; i < samples; i++) {
+                    var t = startTime + (i * step);
+                    try {
+                        var levelValue = audioLevels.valueAtTime(t, true);
+                        levelData.push({ time: t, left: levelValue[0], right: levelValue[1] });
+                    } catch (e) {
+                        levelData.push({ time: t, left: 0, right: 0 });
+                    }
+                }
+            }
+        }
+        // Also get any markers
+        var markers = [];
+        try {
+            var markerProp = layer.property("Marker");
+            if (markerProp && markerProp.numKeys > 0) {
+                for (var k = 1; k <= markerProp.numKeys; k++) {
+                    var mt = markerProp.keyTime(k);
+                    if (mt >= startTime && mt <= endTime) {
+                        markers.push({ time: mt, comment: markerProp.keyValue(k).comment });
+                    }
+                }
+            }
+        } catch (e) { /* ignore marker errors */ }
+        return JSON.stringify({
+            status: "success",
+            message: "Audio waveform data approximated via Audio Levels property",
+            note: "Full PCM waveform data is not accessible via ExtendScript. This returns audio level keyframe values.",
+            layer: { name: layer.name, index: layer.index },
+            startTime: startTime, endTime: endTime, samples: samples,
+            levelData: levelData, markers: markers
+        }, null, 2);
+    } catch (e) { return JSON.stringify({ status: "error", message: e.toString() }, null, 2); }
+}

--- a/src/scripts/getCompFrame.jsx
+++ b/src/scripts/getCompFrame.jsx
@@ -1,0 +1,30 @@
+function getCompFrame(args) {
+    try {
+        var compIndex = args.compIndex || 1;
+        var timeInSeconds = args.timeInSeconds !== undefined ? args.timeInSeconds : 0;
+        var outputDir = args.outputDir;
+        if (!outputDir) {
+            var userFolder = Folder.myDocuments;
+            outputDir = userFolder.fsName + "/ae-mcp-bridge/frames";
+        }
+        // Ensure output directory exists
+        var outFolder = new Folder(outputDir);
+        if (!outFolder.exists) outFolder.create();
+        var comp = app.project.item(compIndex);
+        if (!(comp instanceof CompItem)) throw new Error("Item " + compIndex + " is not a composition");
+        // Generate filename from comp name and time
+        var safeName = comp.name.replace(/[^a-zA-Z0-9_-]/g, "_");
+        var frameNum = Math.round(timeInSeconds * comp.frameRate);
+        var outputPath = outputDir + "/" + safeName + "_frame_" + frameNum + ".png";
+        var rqItem = app.project.renderQueue.items.add(comp);
+        rqItem.timeSpanStart = timeInSeconds;
+        rqItem.timeSpanDuration = 1 / comp.frameRate;
+        var om = rqItem.outputModule(1);
+        om.file = new File(outputPath);
+        try { om.applyTemplate("PNG Sequence"); } catch (e) { /* ignore */ }
+        om.file = new File(outputPath);
+        app.project.renderQueue.render();
+        rqItem.remove();
+        return JSON.stringify({ status: "success", message: "Frame saved to " + outputPath, outputPath: outputPath, time: timeInSeconds }, null, 2);
+    } catch (e) { return JSON.stringify({ status: "error", message: e.toString() }, null, 2); }
+}

--- a/src/scripts/getEffectParams.jsx
+++ b/src/scripts/getEffectParams.jsx
@@ -1,0 +1,39 @@
+function getEffectParams(args) {
+    try {
+        var compIndex = args.compIndex || 1;
+        var layerIndex = args.layerIndex || 1;
+        var effectName = args.effectName;
+        var effectIndex = args.effectIndex;
+        var comp = app.project.item(compIndex);
+        if (!(comp instanceof CompItem)) throw new Error("Item " + compIndex + " is not a composition");
+        var layer = comp.layer(layerIndex);
+        if (!layer) throw new Error("Layer not found at index " + layerIndex);
+        var effects = layer.property("Effects");
+        if (!effects) throw new Error("No effects on this layer");
+        var effect = null;
+        if (effectIndex !== undefined && effectIndex !== null) {
+            effect = effects.property(effectIndex);
+        } else if (effectName) {
+            for (var i = 1; i <= effects.numProperties; i++) {
+                if (effects.property(i).name === effectName) {
+                    effect = effects.property(i);
+                    break;
+                }
+            }
+        }
+        if (!effect) throw new Error("Effect not found: " + (effectName || "index " + effectIndex));
+        var params = [];
+        for (var j = 1; j <= effect.numProperties; j++) {
+            try {
+                var prop = effect.property(j);
+                var paramInfo = { name: prop.name, index: j };
+                try { paramInfo.value = prop.value; } catch (e) { paramInfo.value = null; }
+                params.push(paramInfo);
+            } catch (e) { /* skip properties that can't be read */ }
+        }
+        return JSON.stringify({
+            status: "success", message: "Effect params retrieved",
+            effect: { name: effect.name, matchName: effect.matchName, index: effect.propertyIndex, params: params }
+        }, null, 2);
+    } catch (e) { return JSON.stringify({ status: "error", message: e.toString() }, null, 2); }
+}

--- a/src/scripts/getRendererInfo.jsx
+++ b/src/scripts/getRendererInfo.jsx
@@ -1,0 +1,27 @@
+function getRendererInfo(args) {
+    try {
+        var compIndex = args.compIndex || 1;
+        var comp = app.project.item(compIndex);
+        if (!(comp instanceof CompItem)) throw new Error("Item " + compIndex + " is not a composition");
+        var renderers = [];
+        try {
+            var rendererList = comp.renderers;
+            for (var i = 0; i < rendererList.length; i++) {
+                renderers.push(rendererList[i]);
+            }
+        } catch (e) {
+            // Fallback: known renderer names
+            renderers = ["ADBE Ernst", "ADBE Advanced 3d"];
+        }
+        return JSON.stringify({
+            status: "success",
+            message: "Renderer info retrieved",
+            currentRenderer: comp.renderer,
+            availableRenderers: renderers,
+            rendererDescriptions: {
+                "ADBE Ernst": "Classic 3D renderer",
+                "ADBE Advanced 3d": "Cinema 4D / Advanced 3D renderer"
+            }
+        }, null, 2);
+    } catch (e) { return JSON.stringify({ status: "error", message: e.toString() }, null, 2); }
+}

--- a/src/scripts/importFootage.jsx
+++ b/src/scripts/importFootage.jsx
@@ -1,0 +1,21 @@
+function importFootage(args) {
+    try {
+        var filePath = args.filePath;
+        var name = args.name;
+        var sequenceOptions = args.sequenceOptions || {};
+        if (!filePath) throw new Error("filePath is required");
+        var file = new File(filePath);
+        if (!file.exists) throw new Error("File not found: " + filePath);
+        var importOptions = new ImportOptions(file);
+        if (sequenceOptions.importAsSequence) {
+            importOptions.sequence = true;
+            if (sequenceOptions.frameRate) importOptions.frameRate = sequenceOptions.frameRate;
+        }
+        var footageItem = app.project.importFile(importOptions);
+        if (name) footageItem.name = name;
+        return JSON.stringify({
+            status: "success", message: "Footage imported: " + footageItem.name,
+            footage: { name: footageItem.name, id: footageItem.id }
+        }, null, 2);
+    } catch (e) { return JSON.stringify({ status: "error", message: e.toString() }, null, 2); }
+}

--- a/src/scripts/mcp-bridge-auto.jsx
+++ b/src/scripts/mcp-bridge-auto.jsx
@@ -788,7 +788,1154 @@ function applyEffectTemplate(args) {
     }
 }
 
-// --- End of Function Definitions ---
+// --- End of Original Function Definitions ---
+
+// --- NEW FUNCTIONS ---
+
+// --- createNullObject ---
+function createNullObject(args) {
+    try {
+        var compIndex = args.compIndex || 1;
+        var name = args.name || "Null";
+        var startTime = args.startTime || 0;
+        var duration = args.duration || 0;
+        var comp = app.project.item(compIndex);
+        if (!(comp instanceof CompItem)) throw new Error("Item " + compIndex + " is not a composition");
+        var nullLayer = comp.layers.addNull(duration || comp.duration);
+        nullLayer.name = name;
+        nullLayer.startTime = startTime;
+        return JSON.stringify({
+            status: "success", message: "Null object created",
+            layer: { name: nullLayer.name, index: nullLayer.index, inPoint: nullLayer.inPoint, outPoint: nullLayer.outPoint }
+        }, null, 2);
+    } catch (e) { return JSON.stringify({ status: "error", message: e.toString() }, null, 2); }
+}
+
+// --- createCamera ---
+function createCamera(args) {
+    try {
+        var compIndex = args.compIndex || 1;
+        var name = args.name || "Camera 1";
+        var preset = args.preset || "50mm";
+        var zoom = args.zoom;
+        var filmSize = args.filmSize || 36;
+        var comp = app.project.item(compIndex);
+        if (!(comp instanceof CompItem)) throw new Error("Item " + compIndex + " is not a composition");
+        var centerX = comp.width / 2;
+        var centerY = comp.height / 2;
+        var cameraLayer = comp.layers.addCamera(name, [centerX, centerY]);
+        if (!zoom) {
+            var presetZooms = { "15mm": 135, "20mm": 181, "24mm": 216, "28mm": 252, "35mm": 315, "50mm": 450, "80mm": 720, "85mm": 765, "135mm": 1215, "200mm": 1800 };
+            zoom = presetZooms[preset] || 450;
+        }
+        var cameraOptions = cameraLayer.property("Camera Options");
+        if (cameraOptions) {
+            var zoomProp = cameraOptions.property("Zoom");
+            if (zoomProp) zoomProp.setValue(zoom);
+        }
+        return JSON.stringify({
+            status: "success", message: "Camera layer created",
+            layer: { name: cameraLayer.name, index: cameraLayer.index, preset: preset, zoom: zoom, filmSize: filmSize }
+        }, null, 2);
+    } catch (e) { return JSON.stringify({ status: "error", message: e.toString() }, null, 2); }
+}
+
+// --- createLight ---
+function createLight(args) {
+    try {
+        var compIndex = args.compIndex || 1;
+        var name = args.name || "Light 1";
+        var lightTypeStr = args.lightType || "POINT";
+        var color = args.color || [1, 1, 1];
+        var intensity = args.intensity !== undefined ? args.intensity : 100;
+        var castsShadows = args.castsShadows !== undefined ? args.castsShadows : false;
+        var coneAngle = args.coneAngle || 90;
+        var coneFeather = args.coneFeather || 50;
+        var comp = app.project.item(compIndex);
+        if (!(comp instanceof CompItem)) throw new Error("Item " + compIndex + " is not a composition");
+        var centerX = comp.width / 2;
+        var centerY = comp.height / 2;
+        var lightLayer = comp.layers.addLight(name, [centerX, centerY]);
+        var lightOptions = lightLayer.property("Light Options");
+        if (lightOptions) {
+            var lightTypeMap = { "PARALLEL": LightType.PARALLEL, "SPOT": LightType.SPOT, "POINT": LightType.POINT, "AMBIENT": LightType.AMBIENT };
+            var ltType = lightTypeMap[lightTypeStr.toUpperCase()] || LightType.POINT;
+            var ltProp = lightOptions.property("Light Type");
+            if (ltProp) ltProp.setValue(ltType);
+            var colorProp = lightOptions.property("Color");
+            if (colorProp) colorProp.setValue(color);
+            var intensityProp = lightOptions.property("Intensity");
+            if (intensityProp) intensityProp.setValue(intensity);
+            var shadowsProp = lightOptions.property("Casts Shadows");
+            if (shadowsProp) shadowsProp.setValue(castsShadows ? 1 : 0);
+            if (lightTypeStr.toUpperCase() === "SPOT") {
+                var coneAngleProp = lightOptions.property("Cone Angle");
+                if (coneAngleProp) coneAngleProp.setValue(coneAngle);
+                var coneFeatherProp = lightOptions.property("Cone Feather");
+                if (coneFeatherProp) coneFeatherProp.setValue(coneFeather);
+            }
+        }
+        return JSON.stringify({
+            status: "success", message: "Light layer created",
+            layer: { name: lightLayer.name, index: lightLayer.index, lightType: lightTypeStr, color: color, intensity: intensity, castsShadows: castsShadows }
+        }, null, 2);
+    } catch (e) { return JSON.stringify({ status: "error", message: e.toString() }, null, 2); }
+}
+
+// --- deleteLayer ---
+function deleteLayer(args) {
+    try {
+        var compIndex = args.compIndex || 1;
+        var layerIndex = args.layerIndex || 1;
+        var comp = app.project.item(compIndex);
+        if (!(comp instanceof CompItem)) throw new Error("Item " + compIndex + " is not a composition");
+        var layer = comp.layer(layerIndex);
+        if (!layer) throw new Error("Layer not found at index " + layerIndex);
+        var layerName = layer.name;
+        layer.remove();
+        return JSON.stringify({ status: "success", message: "Layer deleted: " + layerName, layerName: layerName }, null, 2);
+    } catch (e) { return JSON.stringify({ status: "error", message: e.toString() }, null, 2); }
+}
+
+// --- duplicateLayer ---
+function duplicateLayer(args) {
+    try {
+        var compIndex = args.compIndex || 1;
+        var layerIndex = args.layerIndex || 1;
+        var comp = app.project.item(compIndex);
+        if (!(comp instanceof CompItem)) throw new Error("Item " + compIndex + " is not a composition");
+        var layer = comp.layer(layerIndex);
+        if (!layer) throw new Error("Layer not found at index " + layerIndex);
+        var newLayer = layer.duplicate();
+        return JSON.stringify({
+            status: "success", message: "Layer duplicated",
+            layer: { name: newLayer.name, index: newLayer.index, inPoint: newLayer.inPoint, outPoint: newLayer.outPoint }
+        }, null, 2);
+    } catch (e) { return JSON.stringify({ status: "error", message: e.toString() }, null, 2); }
+}
+
+// --- reorderLayer ---
+function reorderLayer(args) {
+    try {
+        var compIndex = args.compIndex || 1;
+        var layerIndex = args.layerIndex || 1;
+        var newIndex = args.newIndex || 1;
+        var comp = app.project.item(compIndex);
+        if (!(comp instanceof CompItem)) throw new Error("Item " + compIndex + " is not a composition");
+        var layer = comp.layer(layerIndex);
+        if (!layer) throw new Error("Layer not found at index " + layerIndex);
+        layer.moveToIndex(newIndex);
+        return JSON.stringify({ status: "success", message: "Layer moved to index " + newIndex, layer: { name: layer.name, index: layer.index } }, null, 2);
+    } catch (e) { return JSON.stringify({ status: "error", message: e.toString() }, null, 2); }
+}
+
+// --- renameLayer ---
+function renameLayer(args) {
+    try {
+        var compIndex = args.compIndex || 1;
+        var layerIndex = args.layerIndex || 1;
+        var newName = args.newName || "Layer";
+        var comp = app.project.item(compIndex);
+        if (!(comp instanceof CompItem)) throw new Error("Item " + compIndex + " is not a composition");
+        var layer = comp.layer(layerIndex);
+        if (!layer) throw new Error("Layer not found at index " + layerIndex);
+        var oldName = layer.name;
+        layer.name = newName;
+        return JSON.stringify({ status: "success", message: "Layer renamed from '" + oldName + "' to '" + newName + "'", layer: { name: layer.name, index: layer.index } }, null, 2);
+    } catch (e) { return JSON.stringify({ status: "error", message: e.toString() }, null, 2); }
+}
+
+// --- setLayerParent ---
+function setLayerParent(args) {
+    try {
+        var compIndex = args.compIndex || 1;
+        var layerIndex = args.layerIndex || 1;
+        var parentLayerIndex = args.parentLayerIndex !== undefined ? args.parentLayerIndex : 0;
+        var comp = app.project.item(compIndex);
+        if (!(comp instanceof CompItem)) throw new Error("Item " + compIndex + " is not a composition");
+        var layer = comp.layer(layerIndex);
+        if (!layer) throw new Error("Layer not found at index " + layerIndex);
+        if (parentLayerIndex === 0 || parentLayerIndex === null) {
+            layer.parent = null;
+            return JSON.stringify({ status: "success", message: "Layer parent cleared", layer: { name: layer.name, index: layer.index, parent: null } }, null, 2);
+        } else {
+            var parentLayer = comp.layer(parentLayerIndex);
+            if (!parentLayer) throw new Error("Parent layer not found at index " + parentLayerIndex);
+            layer.parent = parentLayer;
+            return JSON.stringify({ status: "success", message: "Layer parent set", layer: { name: layer.name, index: layer.index, parent: { name: parentLayer.name, index: parentLayer.index } } }, null, 2);
+        }
+    } catch (e) { return JSON.stringify({ status: "error", message: e.toString() }, null, 2); }
+}
+
+// --- setLayerBlendMode ---
+function setLayerBlendMode(args) {
+    try {
+        var compIndex = args.compIndex || 1;
+        var layerIndex = args.layerIndex || 1;
+        var blendModeStr = args.blendMode || "NORMAL";
+        var comp = app.project.item(compIndex);
+        if (!(comp instanceof CompItem)) throw new Error("Item " + compIndex + " is not a composition");
+        var layer = comp.layer(layerIndex);
+        if (!layer) throw new Error("Layer not found at index " + layerIndex);
+        var blendModeMap = {
+            "NORMAL": BlendingMode.NORMAL, "DISSOLVE": BlendingMode.DISSOLVE,
+            "DANCING_DISSOLVE": BlendingMode.DANCING_DISSOLVE, "DARKEN": BlendingMode.DARKEN,
+            "MULTIPLY": BlendingMode.MULTIPLY, "COLOR_BURN": BlendingMode.COLOR_BURN,
+            "CLASSIC_COLOR_BURN": BlendingMode.CLASSIC_COLOR_BURN, "LINEAR_BURN": BlendingMode.LINEAR_BURN,
+            "DARKER_COLOR": BlendingMode.DARKER_COLOR, "ADD": BlendingMode.ADD,
+            "LIGHTEN": BlendingMode.LIGHTEN, "SCREEN": BlendingMode.SCREEN,
+            "COLOR_DODGE": BlendingMode.COLOR_DODGE, "CLASSIC_COLOR_DODGE": BlendingMode.CLASSIC_COLOR_DODGE,
+            "LINEAR_DODGE": BlendingMode.LINEAR_DODGE, "LIGHTER_COLOR": BlendingMode.LIGHTER_COLOR,
+            "OVERLAY": BlendingMode.OVERLAY, "SOFT_LIGHT": BlendingMode.SOFT_LIGHT,
+            "HARD_LIGHT": BlendingMode.HARD_LIGHT, "LINEAR_LIGHT": BlendingMode.LINEAR_LIGHT,
+            "VIVID_LIGHT": BlendingMode.VIVID_LIGHT, "PIN_LIGHT": BlendingMode.PIN_LIGHT,
+            "HARD_MIX": BlendingMode.HARD_MIX, "DIFFERENCE": BlendingMode.DIFFERENCE,
+            "CLASSIC_DIFFERENCE": BlendingMode.CLASSIC_DIFFERENCE, "EXCLUSION": BlendingMode.EXCLUSION,
+            "HUE": BlendingMode.HUE, "SATURATION": BlendingMode.SATURATION,
+            "COLOR": BlendingMode.COLOR, "LUMINOSITY": BlendingMode.LUMINOSITY,
+            "STENCIL_ALPHA": BlendingMode.STENCIL_ALPHA, "STENCIL_LUMA": BlendingMode.STENCIL_LUMA,
+            "SILHOUETTE_ALPHA": BlendingMode.SILHOUETTE_ALPHA, "SILHOUETTE_LUMA": BlendingMode.SILHOUETTE_LUMA,
+            "ALPHA_ADD": BlendingMode.ALPHA_ADD, "LUMINESCENT_PREMUL": BlendingMode.LUMINESCENT_PREMUL
+        };
+        var mode = blendModeMap[blendModeStr.toUpperCase()];
+        if (mode === undefined) throw new Error("Unknown blend mode: " + blendModeStr);
+        layer.blendingMode = mode;
+        return JSON.stringify({ status: "success", message: "Blend mode set to " + blendModeStr, layer: { name: layer.name, index: layer.index, blendMode: blendModeStr } }, null, 2);
+    } catch (e) { return JSON.stringify({ status: "error", message: e.toString() }, null, 2); }
+}
+
+// --- setLayerTrackMatte ---
+function setLayerTrackMatte(args) {
+    try {
+        var compIndex = args.compIndex || 1;
+        var layerIndex = args.layerIndex || 1;
+        var matteTypeStr = args.matteType || "NONE";
+        var comp = app.project.item(compIndex);
+        if (!(comp instanceof CompItem)) throw new Error("Item " + compIndex + " is not a composition");
+        var layer = comp.layer(layerIndex);
+        if (!layer) throw new Error("Layer not found at index " + layerIndex);
+        var matteMap = {
+            "NONE": TrackMatteType.NO_TRACK_MATTE, "ALPHA": TrackMatteType.ALPHA,
+            "ALPHA_INVERTED": TrackMatteType.ALPHA_INVERTED, "LUMA": TrackMatteType.LUMA,
+            "LUMA_INVERTED": TrackMatteType.LUMA_INVERTED
+        };
+        var matteType = matteMap[matteTypeStr.toUpperCase()];
+        if (matteType === undefined) throw new Error("Unknown matte type: " + matteTypeStr);
+        layer.trackMatteType = matteType;
+        return JSON.stringify({ status: "success", message: "Track matte set to " + matteTypeStr, layer: { name: layer.name, index: layer.index, matteType: matteTypeStr } }, null, 2);
+    } catch (e) { return JSON.stringify({ status: "error", message: e.toString() }, null, 2); }
+}
+
+// --- setLayerFlags ---
+function setLayerFlags(args) {
+    try {
+        var compIndex = args.compIndex || 1;
+        var layerIndex = args.layerIndex || 1;
+        var flags = args.flags || {};
+        var comp = app.project.item(compIndex);
+        if (!(comp instanceof CompItem)) throw new Error("Item " + compIndex + " is not a composition");
+        var layer = comp.layer(layerIndex);
+        if (!layer) throw new Error("Layer not found at index " + layerIndex);
+        var changed = [];
+        if (flags.solo !== undefined) { layer.solo = flags.solo; changed.push("solo=" + flags.solo); }
+        if (flags.shy !== undefined) { layer.shy = flags.shy; changed.push("shy=" + flags.shy); }
+        if (flags.locked !== undefined) { layer.locked = flags.locked; changed.push("locked=" + flags.locked); }
+        if (flags.motionBlur !== undefined) { layer.motionBlur = flags.motionBlur; changed.push("motionBlur=" + flags.motionBlur); }
+        if (flags.enable3D !== undefined) { layer.threeDLayer = flags.enable3D; changed.push("threeDLayer=" + flags.enable3D); }
+        if (flags.adjustmentLayer !== undefined) { layer.adjustmentLayer = flags.adjustmentLayer; changed.push("adjustmentLayer=" + flags.adjustmentLayer); }
+        if (flags.collapseTransformation !== undefined) { layer.collapseTransformation = flags.collapseTransformation; changed.push("collapseTransformation=" + flags.collapseTransformation); }
+        if (flags.frameBlending !== undefined) { layer.frameBlending = flags.frameBlending; changed.push("frameBlending=" + flags.frameBlending); }
+        if (flags.frameBlendingType !== undefined) {
+            var fbTypeMap = { "FRAME_MIX": FrameBlendingType.FRAME_MIX, "PIXEL_MOTION": FrameBlendingType.PIXEL_MOTION };
+            var fbType = fbTypeMap[flags.frameBlendingType];
+            if (fbType !== undefined) { layer.frameBlendingType = fbType; changed.push("frameBlendingType=" + flags.frameBlendingType); }
+        }
+        return JSON.stringify({ status: "success", message: "Layer flags updated: " + changed.join(", "), layer: { name: layer.name, index: layer.index, changed: changed } }, null, 2);
+    } catch (e) { return JSON.stringify({ status: "error", message: e.toString() }, null, 2); }
+}
+
+// --- precomposeLayer ---
+function precomposeLayer(args) {
+    try {
+        var compIndex = args.compIndex || 1;
+        var layerIndices = args.layerIndices || [1];
+        var newCompName = args.newCompName || "Precomp";
+        var moveAllAttributes = args.moveAllAttributes !== undefined ? args.moveAllAttributes : true;
+        var comp = app.project.item(compIndex);
+        if (!(comp instanceof CompItem)) throw new Error("Item " + compIndex + " is not a composition");
+        var indices = [];
+        for (var i = 0; i < layerIndices.length; i++) { indices.push(layerIndices[i]); }
+        var newComp = comp.layers.precompose(indices, newCompName, moveAllAttributes);
+        return JSON.stringify({ status: "success", message: "Precomposed " + indices.length + " layer(s) into '" + newCompName + "'", newComp: { name: newComp.name, id: newComp.id, width: newComp.width, height: newComp.height, duration: newComp.duration } }, null, 2);
+    } catch (e) { return JSON.stringify({ status: "error", message: e.toString() }, null, 2); }
+}
+
+// --- moveLayerToTime ---
+function moveLayerToTime(args) {
+    try {
+        var compIndex = args.compIndex || 1;
+        var layerIndex = args.layerIndex || 1;
+        var startTime = args.startTime !== undefined ? args.startTime : 0;
+        var comp = app.project.item(compIndex);
+        if (!(comp instanceof CompItem)) throw new Error("Item " + compIndex + " is not a composition");
+        var layer = comp.layer(layerIndex);
+        if (!layer) throw new Error("Layer not found at index " + layerIndex);
+        layer.startTime = startTime;
+        return JSON.stringify({ status: "success", message: "Layer moved to time " + startTime, layer: { name: layer.name, index: layer.index, startTime: layer.startTime, inPoint: layer.inPoint, outPoint: layer.outPoint } }, null, 2);
+    } catch (e) { return JSON.stringify({ status: "error", message: e.toString() }, null, 2); }
+}
+
+// --- trimLayer ---
+function trimLayer(args) {
+    try {
+        var compIndex = args.compIndex || 1;
+        var layerIndex = args.layerIndex || 1;
+        var inPoint = args.inPoint;
+        var outPoint = args.outPoint;
+        var comp = app.project.item(compIndex);
+        if (!(comp instanceof CompItem)) throw new Error("Item " + compIndex + " is not a composition");
+        var layer = comp.layer(layerIndex);
+        if (!layer) throw new Error("Layer not found at index " + layerIndex);
+        if (inPoint !== undefined && inPoint !== null) layer.inPoint = inPoint;
+        if (outPoint !== undefined && outPoint !== null) layer.outPoint = outPoint;
+        return JSON.stringify({ status: "success", message: "Layer trimmed", layer: { name: layer.name, index: layer.index, inPoint: layer.inPoint, outPoint: layer.outPoint } }, null, 2);
+    } catch (e) { return JSON.stringify({ status: "error", message: e.toString() }, null, 2); }
+}
+
+// --- splitLayer ---
+function splitLayer(args) {
+    try {
+        var compIndex = args.compIndex || 1;
+        var layerIndex = args.layerIndex || 1;
+        var splitTime = args.splitTime !== undefined ? args.splitTime : 1;
+        var comp = app.project.item(compIndex);
+        if (!(comp instanceof CompItem)) throw new Error("Item " + compIndex + " is not a composition");
+        var layer = comp.layer(layerIndex);
+        if (!layer) throw new Error("Layer not found at index " + layerIndex);
+        if (splitTime <= layer.inPoint || splitTime >= layer.outPoint) {
+            throw new Error("splitTime " + splitTime + " must be between layer inPoint " + layer.inPoint + " and outPoint " + layer.outPoint);
+        }
+        var origOutPoint = layer.outPoint;
+        var newLayer = layer.duplicate();
+        layer.outPoint = splitTime;
+        newLayer.inPoint = splitTime;
+        newLayer.outPoint = origOutPoint;
+        newLayer.moveAfter(layer);
+        return JSON.stringify({ status: "success", message: "Layer split at " + splitTime, originalLayer: { name: layer.name, index: layer.index, inPoint: layer.inPoint, outPoint: layer.outPoint }, newLayer: { name: newLayer.name, index: newLayer.index, inPoint: newLayer.inPoint, outPoint: newLayer.outPoint } }, null, 2);
+    } catch (e) { return JSON.stringify({ status: "error", message: e.toString() }, null, 2); }
+}
+
+// --- addMask ---
+function addMask(args) {
+    try {
+        var compIndex = args.compIndex || 1;
+        var layerIndex = args.layerIndex || 1;
+        var maskShape = args.maskShape || "rectangle";
+        var vertices = args.vertices || [];
+        var inverted = args.inverted !== undefined ? args.inverted : false;
+        var comp = app.project.item(compIndex);
+        if (!(comp instanceof CompItem)) throw new Error("Item " + compIndex + " is not a composition");
+        var layer = comp.layer(layerIndex);
+        if (!layer) throw new Error("Layer not found at index " + layerIndex);
+        var maskGroup = layer.property("Masks");
+        var mask = maskGroup.addProperty("Mask");
+        mask.inverted = inverted;
+        var maskPath = mask.property("Mask Path");
+        var shape = new Shape();
+        var w = comp.width;
+        var h = comp.height;
+        if (maskShape === "rectangle") {
+            shape.vertices = [[0, 0], [w, 0], [w, h], [0, h]];
+            shape.inTangents = [[0, 0], [0, 0], [0, 0], [0, 0]];
+            shape.outTangents = [[0, 0], [0, 0], [0, 0], [0, 0]];
+            shape.closed = true;
+        } else if (maskShape === "ellipse") {
+            var cx = w / 2; var cy = h / 2; var rx = w / 2; var ry = h / 2; var k = 0.5522847498;
+            shape.vertices = [[cx, cy - ry], [cx + rx, cy], [cx, cy + ry], [cx - rx, cy]];
+            shape.inTangents = [[-k * rx, 0], [0, -k * ry], [k * rx, 0], [0, k * ry]];
+            shape.outTangents = [[k * rx, 0], [0, k * ry], [-k * rx, 0], [0, -k * ry]];
+            shape.closed = true;
+        } else if (maskShape === "freeform" && vertices.length >= 3) {
+            var verts = []; var inTans = []; var outTans = [];
+            for (var i = 0; i < vertices.length; i++) { verts.push([vertices[i][0], vertices[i][1]]); inTans.push([0, 0]); outTans.push([0, 0]); }
+            shape.vertices = verts; shape.inTangents = inTans; shape.outTangents = outTans; shape.closed = true;
+        } else {
+            shape.vertices = [[0, 0], [w, 0], [w, h], [0, h]];
+            shape.inTangents = [[0, 0], [0, 0], [0, 0], [0, 0]];
+            shape.outTangents = [[0, 0], [0, 0], [0, 0], [0, 0]];
+            shape.closed = true;
+        }
+        maskPath.setValue(shape);
+        return JSON.stringify({ status: "success", message: "Mask added", mask: { index: mask.propertyIndex, inverted: inverted, shape: maskShape } }, null, 2);
+    } catch (e) { return JSON.stringify({ status: "error", message: e.toString() }, null, 2); }
+}
+
+// --- setMaskProperties ---
+function setMaskProperties(args) {
+    try {
+        var compIndex = args.compIndex || 1;
+        var layerIndex = args.layerIndex || 1;
+        var maskIndex = args.maskIndex || 1;
+        var comp = app.project.item(compIndex);
+        if (!(comp instanceof CompItem)) throw new Error("Item " + compIndex + " is not a composition");
+        var layer = comp.layer(layerIndex);
+        if (!layer) throw new Error("Layer not found at index " + layerIndex);
+        var maskGroup = layer.property("Masks");
+        var mask = maskGroup.property(maskIndex);
+        if (!mask) throw new Error("Mask not found at index " + maskIndex);
+        var changed = [];
+        if (args.feather !== undefined && args.feather !== null) {
+            var featherProp = mask.property("Mask Feather");
+            if (featherProp) { featherProp.setValue(args.feather instanceof Array ? args.feather : [args.feather, args.feather]); changed.push("feather"); }
+        }
+        if (args.opacity !== undefined && args.opacity !== null) {
+            var opacityProp = mask.property("Mask Opacity");
+            if (opacityProp) { opacityProp.setValue(args.opacity); changed.push("opacity"); }
+        }
+        if (args.expansion !== undefined && args.expansion !== null) {
+            var expansionProp = mask.property("Mask Expansion");
+            if (expansionProp) { expansionProp.setValue(args.expansion); changed.push("expansion"); }
+        }
+        if (args.inverted !== undefined) { mask.inverted = args.inverted; changed.push("inverted"); }
+        if (args.mode !== undefined) {
+            var modeMap = { "NONE": MaskMode.NONE, "ADD": MaskMode.ADD, "SUBTRACT": MaskMode.SUBTRACT, "INTERSECT": MaskMode.INTERSECT, "LIGHTEN": MaskMode.LIGHTEN, "DARKEN": MaskMode.DARKEN, "DIFFERENCE": MaskMode.DIFFERENCE };
+            var mode = modeMap[args.mode.toUpperCase()];
+            if (mode !== undefined) { mask.maskMode = mode; changed.push("mode"); }
+        }
+        return JSON.stringify({ status: "success", message: "Mask properties updated: " + changed.join(", "), mask: { index: maskIndex, changed: changed } }, null, 2);
+    } catch (e) { return JSON.stringify({ status: "error", message: e.toString() }, null, 2); }
+}
+
+// --- deleteMask ---
+function deleteMask(args) {
+    try {
+        var compIndex = args.compIndex || 1;
+        var layerIndex = args.layerIndex || 1;
+        var maskIndex = args.maskIndex || 1;
+        var comp = app.project.item(compIndex);
+        if (!(comp instanceof CompItem)) throw new Error("Item " + compIndex + " is not a composition");
+        var layer = comp.layer(layerIndex);
+        if (!layer) throw new Error("Layer not found at index " + layerIndex);
+        var maskGroup = layer.property("Masks");
+        var mask = maskGroup.property(maskIndex);
+        if (!mask) throw new Error("Mask not found at index " + maskIndex);
+        mask.remove();
+        return JSON.stringify({ status: "success", message: "Mask " + maskIndex + " deleted" }, null, 2);
+    } catch (e) { return JSON.stringify({ status: "error", message: e.toString() }, null, 2); }
+}
+
+// --- importFootage ---
+function importFootage(args) {
+    try {
+        var filePath = args.filePath;
+        var name = args.name;
+        var sequenceOptions = args.sequenceOptions || {};
+        if (!filePath) throw new Error("filePath is required");
+        var file = new File(filePath);
+        if (!file.exists) throw new Error("File not found: " + filePath);
+        var importOptions = new ImportOptions(file);
+        if (sequenceOptions.importAsSequence) {
+            importOptions.sequence = true;
+            if (sequenceOptions.frameRate) importOptions.frameRate = sequenceOptions.frameRate;
+        }
+        var footageItem = app.project.importFile(importOptions);
+        if (name) footageItem.name = name;
+        return JSON.stringify({ status: "success", message: "Footage imported: " + footageItem.name, footage: { name: footageItem.name, id: footageItem.id } }, null, 2);
+    } catch (e) { return JSON.stringify({ status: "error", message: e.toString() }, null, 2); }
+}
+
+// --- saveProject ---
+function saveProject(args) {
+    try {
+        var filePath = args.filePath;
+        if (filePath) {
+            var file = new File(filePath);
+            app.project.save(file);
+            return JSON.stringify({ status: "success", message: "Project saved to: " + filePath, path: filePath }, null, 2);
+        } else {
+            app.project.save();
+            var savedPath = app.project.file ? app.project.file.fsName : "Untitled";
+            return JSON.stringify({ status: "success", message: "Project saved", path: savedPath }, null, 2);
+        }
+    } catch (e) { return JSON.stringify({ status: "error", message: e.toString() }, null, 2); }
+}
+
+// --- replaceFootage ---
+function replaceFootage(args) {
+    try {
+        var itemIndex = args.itemIndex || 1;
+        var newFilePath = args.newFilePath;
+        if (!newFilePath) throw new Error("newFilePath is required");
+        var item = app.project.item(itemIndex);
+        if (!item) throw new Error("Item not found at index " + itemIndex);
+        if (!(item instanceof FootageItem)) throw new Error("Item at index " + itemIndex + " is not a footage item");
+        var newFile = new File(newFilePath);
+        if (!newFile.exists) throw new Error("File not found: " + newFilePath);
+        item.replace(newFile);
+        return JSON.stringify({ status: "success", message: "Footage replaced with: " + newFilePath, footage: { name: item.name, id: item.id } }, null, 2);
+    } catch (e) { return JSON.stringify({ status: "error", message: e.toString() }, null, 2); }
+}
+
+// --- addToRenderQueue ---
+function addToRenderQueue(args) {
+    try {
+        var compIndex = args.compIndex || 1;
+        var outputPath = args.outputPath;
+        var outputModuleTemplate = args.outputModuleTemplate || "Lossless";
+        var renderSettingsTemplate = args.renderSettingsTemplate || "Best Settings";
+        if (!outputPath) throw new Error("outputPath is required");
+        var comp = app.project.item(compIndex);
+        if (!(comp instanceof CompItem)) throw new Error("Item " + compIndex + " is not a composition");
+        var rqItem = app.project.renderQueue.items.add(comp);
+        try { rqItem.applyTemplate(renderSettingsTemplate); } catch (e) { /* use defaults */ }
+        var om = rqItem.outputModule(1);
+        try { om.applyTemplate(outputModuleTemplate); } catch (e) { /* use defaults */ }
+        om.file = new File(outputPath);
+        return JSON.stringify({ status: "success", message: "Added to render queue", renderQueueItem: { index: rqItem.index, outputPath: outputPath, comp: comp.name } }, null, 2);
+    } catch (e) { return JSON.stringify({ status: "error", message: e.toString() }, null, 2); }
+}
+
+// --- renderQueue ---
+function renderQueue(args) {
+    try {
+        var action = args.action || "status";
+        var rq = app.project.renderQueue;
+        if (action === "start") {
+            rq.render();
+            return JSON.stringify({ status: "success", message: "Render started", action: "start" }, null, 2);
+        } else if (action === "stop") {
+            rq.stopRendering();
+            return JSON.stringify({ status: "success", message: "Render stopped", action: "stop" }, null, 2);
+        } else if (action === "clear") {
+            var removed = 0;
+            for (var i = rq.numItems; i >= 1; i--) { try { rq.item(i).remove(); removed++; } catch (e) { /* skip */ } }
+            return JSON.stringify({ status: "success", message: "Cleared " + removed + " items from render queue", action: "clear" }, null, 2);
+        } else {
+            var items = [];
+            for (var j = 1; j <= rq.numItems; j++) { var item = rq.item(j); items.push({ index: j, comp: item.comp ? item.comp.name : "Unknown", status: item.status.toString() }); }
+            return JSON.stringify({ status: "success", action: "status", numItems: rq.numItems, items: items }, null, 2);
+        }
+    } catch (e) { return JSON.stringify({ status: "error", message: e.toString() }, null, 2); }
+}
+
+// --- exportFrame ---
+function exportFrame(args) {
+    try {
+        var compIndex = args.compIndex || 1;
+        var timeInSeconds = args.timeInSeconds !== undefined ? args.timeInSeconds : 0;
+        var outputPath = args.outputPath;
+        if (!outputPath) throw new Error("outputPath is required");
+        var comp = app.project.item(compIndex);
+        if (!(comp instanceof CompItem)) throw new Error("Item " + compIndex + " is not a composition");
+        var rqItem = app.project.renderQueue.items.add(comp);
+        rqItem.timeSpanStart = timeInSeconds;
+        rqItem.timeSpanDuration = 1 / comp.frameRate;
+        var om = rqItem.outputModule(1);
+        om.file = new File(outputPath);
+        try { om.applyTemplate("PNG Sequence"); } catch (e) { /* ignore */ }
+        om.file = new File(outputPath);
+        app.project.renderQueue.render();
+        rqItem.remove();
+        return JSON.stringify({ status: "success", message: "Frame exported to " + outputPath, outputPath: outputPath, time: timeInSeconds }, null, 2);
+    } catch (e) { return JSON.stringify({ status: "error", message: e.toString() }, null, 2); }
+}
+
+// --- setCompositionSettings ---
+function setCompositionSettings(args) {
+    try {
+        var compIndex = args.compIndex || 1;
+        var comp = app.project.item(compIndex);
+        if (!(comp instanceof CompItem)) throw new Error("Item " + compIndex + " is not a composition");
+        var changed = [];
+        if (args.name !== undefined) { comp.name = args.name; changed.push("name"); }
+        if (args.width !== undefined) { comp.width = args.width; changed.push("width"); }
+        if (args.height !== undefined) { comp.height = args.height; changed.push("height"); }
+        if (args.frameRate !== undefined) { comp.frameRate = args.frameRate; changed.push("frameRate"); }
+        if (args.duration !== undefined) { comp.duration = args.duration; changed.push("duration"); }
+        if (args.pixelAspect !== undefined) { comp.pixelAspect = args.pixelAspect; changed.push("pixelAspect"); }
+        if (args.bgColor !== undefined) {
+            var bg = args.bgColor;
+            comp.bgColor = [bg.r !== undefined ? bg.r : bg[0], bg.g !== undefined ? bg.g : bg[1], bg.b !== undefined ? bg.b : bg[2]];
+            changed.push("bgColor");
+        }
+        return JSON.stringify({ status: "success", message: "Composition settings updated: " + changed.join(", "), composition: { name: comp.name, width: comp.width, height: comp.height, frameRate: comp.frameRate, duration: comp.duration, pixelAspect: comp.pixelAspect } }, null, 2);
+    } catch (e) { return JSON.stringify({ status: "error", message: e.toString() }, null, 2); }
+}
+
+// --- setWorkArea ---
+function setWorkArea(args) {
+    try {
+        var compIndex = args.compIndex || 1;
+        var workAreaStart = args.workAreaStart !== undefined ? args.workAreaStart : 0;
+        var workAreaDuration = args.workAreaDuration;
+        var comp = app.project.item(compIndex);
+        if (!(comp instanceof CompItem)) throw new Error("Item " + compIndex + " is not a composition");
+        comp.workAreaStart = workAreaStart;
+        if (workAreaDuration !== undefined && workAreaDuration !== null) comp.workAreaDuration = workAreaDuration;
+        return JSON.stringify({ status: "success", message: "Work area set", workArea: { start: comp.workAreaStart, duration: comp.workAreaDuration, end: comp.workAreaStart + comp.workAreaDuration } }, null, 2);
+    } catch (e) { return JSON.stringify({ status: "error", message: e.toString() }, null, 2); }
+}
+
+// --- trimCompToWorkArea ---
+function trimCompToWorkArea(args) {
+    try {
+        var compIndex = args.compIndex || 1;
+        var comp = app.project.item(compIndex);
+        if (!(comp instanceof CompItem)) throw new Error("Item " + compIndex + " is not a composition");
+        var waStart = comp.workAreaStart;
+        var waDuration = comp.workAreaDuration;
+        if (waStart > 0) {
+            for (var i = 1; i <= comp.numLayers; i++) { comp.layer(i).startTime = comp.layer(i).startTime - waStart; }
+        }
+        comp.duration = waDuration;
+        comp.workAreaStart = 0;
+        return JSON.stringify({ status: "success", message: "Composition trimmed to work area", composition: { name: comp.name, duration: comp.duration, workAreaStart: comp.workAreaStart, workAreaDuration: comp.workAreaDuration } }, null, 2);
+    } catch (e) { return JSON.stringify({ status: "error", message: e.toString() }, null, 2); }
+}
+
+// --- addMarker ---
+function addMarker(args) {
+    try {
+        var compIndex = args.compIndex || 1;
+        var layerIndex = args.layerIndex;
+        var time = args.time !== undefined ? args.time : 0;
+        var comment = args.comment || "";
+        var duration = args.duration || 0;
+        var url = args.url || "";
+        var comp = app.project.item(compIndex);
+        if (!(comp instanceof CompItem)) throw new Error("Item " + compIndex + " is not a composition");
+        var mv = new MarkerValue(comment);
+        if (duration > 0) mv.duration = duration;
+        if (url) mv.url = url;
+        if (layerIndex && layerIndex > 0) {
+            var layer = comp.layer(layerIndex);
+            if (!layer) throw new Error("Layer not found at index " + layerIndex);
+            layer.property("Marker").setValueAtTime(time, mv);
+            return JSON.stringify({ status: "success", message: "Layer marker added at time " + time, markerType: "layer", time: time, comment: comment }, null, 2);
+        } else {
+            comp.markerProperty.setValueAtTime(time, mv);
+            return JSON.stringify({ status: "success", message: "Composition marker added at time " + time, markerType: "composition", time: time, comment: comment }, null, 2);
+        }
+    } catch (e) { return JSON.stringify({ status: "error", message: e.toString() }, null, 2); }
+}
+
+// --- removeEffect ---
+function removeEffect(args) {
+    try {
+        var compIndex = args.compIndex || 1;
+        var layerIndex = args.layerIndex || 1;
+        var effectName = args.effectName;
+        var effectIndex = args.effectIndex;
+        var comp = app.project.item(compIndex);
+        if (!(comp instanceof CompItem)) throw new Error("Item " + compIndex + " is not a composition");
+        var layer = comp.layer(layerIndex);
+        if (!layer) throw new Error("Layer not found at index " + layerIndex);
+        var effects = layer.property("Effects");
+        if (!effects) throw new Error("No effects on this layer");
+        var effect = null;
+        if (effectIndex !== undefined && effectIndex !== null) {
+            effect = effects.property(effectIndex);
+        } else if (effectName) {
+            for (var i = 1; i <= effects.numProperties; i++) { if (effects.property(i).name === effectName) { effect = effects.property(i); break; } }
+        }
+        if (!effect) throw new Error("Effect not found: " + (effectName || "index " + effectIndex));
+        var removedName = effect.name;
+        effect.remove();
+        return JSON.stringify({ status: "success", message: "Effect removed: " + removedName }, null, 2);
+    } catch (e) { return JSON.stringify({ status: "error", message: e.toString() }, null, 2); }
+}
+
+// --- getEffectParams ---
+function getEffectParams(args) {
+    try {
+        var compIndex = args.compIndex || 1;
+        var layerIndex = args.layerIndex || 1;
+        var effectName = args.effectName;
+        var effectIndex = args.effectIndex;
+        var comp = app.project.item(compIndex);
+        if (!(comp instanceof CompItem)) throw new Error("Item " + compIndex + " is not a composition");
+        var layer = comp.layer(layerIndex);
+        if (!layer) throw new Error("Layer not found at index " + layerIndex);
+        var effects = layer.property("Effects");
+        if (!effects) throw new Error("No effects on this layer");
+        var effect = null;
+        if (effectIndex !== undefined && effectIndex !== null) {
+            effect = effects.property(effectIndex);
+        } else if (effectName) {
+            for (var i = 1; i <= effects.numProperties; i++) { if (effects.property(i).name === effectName) { effect = effects.property(i); break; } }
+        }
+        if (!effect) throw new Error("Effect not found: " + (effectName || "index " + effectIndex));
+        var params = [];
+        for (var j = 1; j <= effect.numProperties; j++) {
+            try { var prop = effect.property(j); var paramInfo = { name: prop.name, index: j }; try { paramInfo.value = prop.value; } catch (e) { paramInfo.value = null; } params.push(paramInfo); } catch (e) { /* skip */ }
+        }
+        return JSON.stringify({ status: "success", message: "Effect params retrieved", effect: { name: effect.name, matchName: effect.matchName, index: effect.propertyIndex, params: params } }, null, 2);
+    } catch (e) { return JSON.stringify({ status: "error", message: e.toString() }, null, 2); }
+}
+
+// --- setEffectParam ---
+function setEffectParam(args) {
+    try {
+        var compIndex = args.compIndex || 1;
+        var layerIndex = args.layerIndex || 1;
+        var effectName = args.effectName;
+        var paramName = args.paramName;
+        var value = args.value;
+        if (!effectName) throw new Error("effectName is required");
+        if (!paramName) throw new Error("paramName is required");
+        if (value === undefined) throw new Error("value is required");
+        var comp = app.project.item(compIndex);
+        if (!(comp instanceof CompItem)) throw new Error("Item " + compIndex + " is not a composition");
+        var layer = comp.layer(layerIndex);
+        if (!layer) throw new Error("Layer not found at index " + layerIndex);
+        var effects = layer.property("Effects");
+        var effect = null;
+        for (var i = 1; i <= effects.numProperties; i++) { if (effects.property(i).name === effectName) { effect = effects.property(i); break; } }
+        if (!effect) throw new Error("Effect not found: " + effectName);
+        var param = null;
+        try { param = effect.property(paramName); } catch (e) { param = null; }
+        if (!param) { for (var j = 1; j <= effect.numProperties; j++) { if (effect.property(j).name === paramName) { param = effect.property(j); break; } } }
+        if (!param) throw new Error("Parameter not found: " + paramName);
+        param.setValue(value);
+        return JSON.stringify({ status: "success", message: "Effect parameter set: " + paramName, effect: effectName, param: paramName, value: value }, null, 2);
+    } catch (e) { return JSON.stringify({ status: "error", message: e.toString() }, null, 2); }
+}
+
+// --- setAudioLevel ---
+function setAudioLevel(args) {
+    try {
+        var compIndex = args.compIndex || 1;
+        var layerIndex = args.layerIndex || 1;
+        var level = args.level !== undefined ? args.level : 0;
+        var timeInSeconds = args.timeInSeconds;
+        var comp = app.project.item(compIndex);
+        if (!(comp instanceof CompItem)) throw new Error("Item " + compIndex + " is not a composition");
+        var layer = comp.layer(layerIndex);
+        if (!layer) throw new Error("Layer not found at index " + layerIndex);
+        var audio = layer.property("Audio");
+        if (!audio) throw new Error("Layer does not have audio properties");
+        var audioLevels = audio.property("Audio Levels");
+        if (!audioLevels) throw new Error("Audio Levels property not found");
+        if (timeInSeconds !== undefined && timeInSeconds !== null) {
+            audioLevels.setValueAtTime(timeInSeconds, [level, level]);
+            return JSON.stringify({ status: "success", message: "Audio level keyframe set at " + timeInSeconds + "s: " + level + " dB", level: level, time: timeInSeconds }, null, 2);
+        } else {
+            audioLevels.setValue([level, level]);
+            return JSON.stringify({ status: "success", message: "Audio level set to " + level + " dB", level: level }, null, 2);
+        }
+    } catch (e) { return JSON.stringify({ status: "error", message: e.toString() }, null, 2); }
+}
+
+// --- enableTimeRemap ---
+function enableTimeRemap(args) {
+    try {
+        var compIndex = args.compIndex || 1;
+        var layerIndex = args.layerIndex || 1;
+        var comp = app.project.item(compIndex);
+        if (!(comp instanceof CompItem)) throw new Error("Item " + compIndex + " is not a composition");
+        var layer = comp.layer(layerIndex);
+        if (!layer) throw new Error("Layer not found at index " + layerIndex);
+        layer.timeRemapEnabled = true;
+        return JSON.stringify({ status: "success", message: "Time remap enabled", layer: { name: layer.name, index: layer.index, timeRemapEnabled: layer.timeRemapEnabled } }, null, 2);
+    } catch (e) { return JSON.stringify({ status: "error", message: e.toString() }, null, 2); }
+}
+
+// --- setTimeRemapKeyframe ---
+function setTimeRemapKeyframe(args) {
+    try {
+        var compIndex = args.compIndex || 1;
+        var layerIndex = args.layerIndex || 1;
+        var timeInSeconds = args.timeInSeconds !== undefined ? args.timeInSeconds : 0;
+        var remapValue = args.remapValue !== undefined ? args.remapValue : 0;
+        var comp = app.project.item(compIndex);
+        if (!(comp instanceof CompItem)) throw new Error("Item " + compIndex + " is not a composition");
+        var layer = comp.layer(layerIndex);
+        if (!layer) throw new Error("Layer not found at index " + layerIndex);
+        if (!layer.timeRemapEnabled) layer.timeRemapEnabled = true;
+        var timeRemap = layer.property("Time Remap");
+        if (!timeRemap) throw new Error("Time Remap property not found");
+        timeRemap.setValueAtTime(timeInSeconds, remapValue);
+        return JSON.stringify({ status: "success", message: "Time remap keyframe set at " + timeInSeconds + "s to " + remapValue, timeInSeconds: timeInSeconds, remapValue: remapValue }, null, 2);
+    } catch (e) { return JSON.stringify({ status: "error", message: e.toString() }, null, 2); }
+}
+
+// --- executeScript ---
+function executeScript(args) {
+    try {
+        var script = args.script;
+        if (!script) throw new Error("script is required");
+        var result;
+        try { result = eval(script); } catch (evalErr) { return JSON.stringify({ status: "error", message: "Script execution error: " + evalErr.toString() }, null, 2); }
+        var resultStr;
+        if (result === undefined || result === null) { resultStr = String(result); }
+        else if (typeof result === "object") { try { resultStr = JSON.stringify(result); } catch (e) { resultStr = result.toString(); } }
+        else { resultStr = String(result); }
+        return JSON.stringify({ status: "success", message: "Script executed successfully", result: resultStr }, null, 2);
+    } catch (e) { return JSON.stringify({ status: "error", message: e.toString() }, null, 2); }
+}
+
+// --- getCompFrame ---
+function getCompFrame(args) {
+    try {
+        var compIndex = args.compIndex || 1;
+        var timeInSeconds = args.timeInSeconds !== undefined ? args.timeInSeconds : 0;
+        var outputDir = args.outputDir;
+        if (!outputDir) {
+            var userFolder = Folder.myDocuments;
+            outputDir = userFolder.fsName + "/ae-mcp-bridge/frames";
+        }
+        var outFolder = new Folder(outputDir);
+        if (!outFolder.exists) outFolder.create();
+        var comp = app.project.item(compIndex);
+        if (!(comp instanceof CompItem)) throw new Error("Item " + compIndex + " is not a composition");
+        var safeName = comp.name.replace(/[^a-zA-Z0-9_-]/g, "_");
+        var frameNum = Math.round(timeInSeconds * comp.frameRate);
+        var outputPath = outputDir + "/" + safeName + "_frame_" + frameNum + ".png";
+        var rqItem = app.project.renderQueue.items.add(comp);
+        rqItem.timeSpanStart = timeInSeconds;
+        rqItem.timeSpanDuration = 1 / comp.frameRate;
+        var om = rqItem.outputModule(1);
+        om.file = new File(outputPath);
+        try { om.applyTemplate("PNG Sequence"); } catch (e) { /* ignore */ }
+        om.file = new File(outputPath);
+        app.project.renderQueue.render();
+        rqItem.remove();
+        return JSON.stringify({ status: "success", message: "Frame saved to " + outputPath, outputPath: outputPath, time: timeInSeconds }, null, 2);
+    } catch (e) { return JSON.stringify({ status: "error", message: e.toString() }, null, 2); }
+}
+
+// --- createCaption ---
+function createCaption(args) {
+    try {
+        var compIndex = args.compIndex || 1;
+        var text = args.text || "Caption";
+        var startTime = args.startTime !== undefined ? args.startTime : 0;
+        var endTime = args.endTime !== undefined ? args.endTime : startTime + 3;
+        var style = args.style || "lower-third";
+        var fontSize = args.fontSize || 36;
+        var color = args.color || [1, 1, 1];
+        var fontFamily = args.fontFamily || "Arial";
+        var backgroundColor = args.backgroundColor;
+        var comp = app.project.item(compIndex);
+        if (!(comp instanceof CompItem)) throw new Error("Item " + compIndex + " is not a composition");
+        var posX = comp.width / 2;
+        var posY;
+        if (style === "lower-third") { posY = comp.height * 0.8; }
+        else if (style === "upper-third") { posY = comp.height * 0.15; }
+        else if (style === "center") { posY = comp.height / 2; }
+        else { posY = comp.height * 0.8; }
+        if (backgroundColor) {
+            var bgColor = [backgroundColor.r || 0, backgroundColor.g || 0, backgroundColor.b || 0];
+            var bgOpacity = backgroundColor.opacity !== undefined ? backgroundColor.opacity : 70;
+            var bgSolid = comp.layers.addSolid(bgColor, "Caption BG", comp.width, Math.round(fontSize * 2), 1);
+            bgSolid.property("Position").setValue([posX, posY]);
+            bgSolid.startTime = startTime;
+            bgSolid.outPoint = endTime;
+            bgSolid.property("Opacity").setValue(bgOpacity);
+        }
+        var textLayer = comp.layers.addText(text);
+        var textProp = textLayer.property("ADBE Text Properties").property("ADBE Text Document");
+        var textDocument = textProp.value;
+        textDocument.fontSize = fontSize;
+        textDocument.fillColor = color;
+        textDocument.font = fontFamily;
+        textDocument.justification = ParagraphJustification.CENTER_JUSTIFY;
+        textProp.setValue(textDocument);
+        textLayer.property("Position").setValue([posX, posY]);
+        textLayer.startTime = startTime;
+        textLayer.outPoint = endTime;
+        textLayer.name = "Caption: " + text.substring(0, 20);
+        return JSON.stringify({ status: "success", message: "Caption created", layer: { name: textLayer.name, index: textLayer.index, position: [posX, posY], startTime: startTime, endTime: endTime, style: style } }, null, 2);
+    } catch (e) { return JSON.stringify({ status: "error", message: e.toString() }, null, 2); }
+}
+
+// --- createZoomEffect ---
+function createZoomEffect(args) {
+    try {
+        var compIndex = args.compIndex || 1;
+        var layerIndex = args.layerIndex || 1;
+        var startTime = args.startTime !== undefined ? args.startTime : 0;
+        var endTime = args.endTime !== undefined ? args.endTime : 1;
+        var zoomFrom = args.zoomFrom !== undefined ? args.zoomFrom : 100;
+        var zoomTo = args.zoomTo !== undefined ? args.zoomTo : 120;
+        var easingType = args.easingType || "ease-in-out";
+        var anchorPoint = args.anchorPoint;
+        var comp = app.project.item(compIndex);
+        if (!(comp instanceof CompItem)) throw new Error("Item " + compIndex + " is not a composition");
+        var layer = comp.layer(layerIndex);
+        if (!layer) throw new Error("Layer not found at index " + layerIndex);
+        var scaleProp = layer.property("Transform").property("Scale");
+        if (!scaleProp) throw new Error("Scale property not found");
+        if (anchorPoint) { var apProp = layer.property("Transform").property("Anchor Point"); if (apProp) apProp.setValue(anchorPoint); }
+        scaleProp.setValueAtTime(startTime, [zoomFrom, zoomFrom]);
+        scaleProp.setValueAtTime(endTime, [zoomTo, zoomTo]);
+        var numKeys = scaleProp.numKeys;
+        if (numKeys >= 2) {
+            var easeIn, easeOut;
+            if (easingType === "ease-in-out") {
+                easeIn = [new KeyframeEase(33, 33)]; easeOut = [new KeyframeEase(33, 33)];
+                scaleProp.setTemporalEaseAtKey(numKeys - 1, easeIn, easeOut);
+                scaleProp.setTemporalEaseAtKey(numKeys, easeIn, easeOut);
+            } else if (easingType === "ease-in") {
+                easeIn = [new KeyframeEase(0, 33)]; easeOut = [new KeyframeEase(33, 33)];
+                scaleProp.setTemporalEaseAtKey(numKeys - 1, easeIn, easeOut);
+            } else if (easingType === "ease-out") {
+                easeIn = [new KeyframeEase(33, 33)]; easeOut = [new KeyframeEase(33, 0)];
+                scaleProp.setTemporalEaseAtKey(numKeys, easeIn, easeOut);
+            }
+        }
+        return JSON.stringify({ status: "success", message: "Zoom effect created from " + zoomFrom + "% to " + zoomTo + "%", layer: { name: layer.name, index: layer.index, zoomFrom: zoomFrom, zoomTo: zoomTo, startTime: startTime, endTime: endTime, easingType: easingType } }, null, 2);
+    } catch (e) { return JSON.stringify({ status: "error", message: e.toString() }, null, 2); }
+}
+
+// --- addTextAnimator ---
+function addTextAnimator(args) {
+    try {
+        var compIndex = args.compIndex || 1;
+        var layerIndex = args.layerIndex || 1;
+        var animatorType = args.animatorType || "opacity";
+        var rangeStart = args.rangeStart !== undefined ? args.rangeStart : 0;
+        var rangeEnd = args.rangeEnd !== undefined ? args.rangeEnd : 100;
+        var value = args.value;
+        var comp = app.project.item(compIndex);
+        if (!(comp instanceof CompItem)) throw new Error("Item " + compIndex + " is not a composition");
+        var layer = comp.layer(layerIndex);
+        if (!layer) throw new Error("Layer not found at index " + layerIndex);
+        if (!(layer instanceof TextLayer)) throw new Error("Layer is not a text layer");
+        var textProps = layer.property("Text");
+        var animators = textProps.property("Animators");
+        var animator = animators.addProperty("ADBE Text Animator");
+        var selectors = animator.property("Selector");
+        if (!selectors || selectors.numProperties === 0) { animator.property("Selector").addProperty("ADBE Text Selector"); }
+        var selector = animator.property("Selector").property(1);
+        if (selector) {
+            var startProp = selector.property("Start");
+            var endProp = selector.property("End");
+            if (startProp) startProp.setValue(rangeStart);
+            if (endProp) endProp.setValue(rangeEnd);
+        }
+        var animProps = animator.property("Animator Properties");
+        var typeMap = { "opacity": "ADBE Text Opacity", "position": "ADBE Text Position", "scale": "ADBE Text Scale", "rotation": "ADBE Text Rotation", "fill_color": "ADBE Text Fill Color", "character_offset": "ADBE Text Character Change Type", "blur": "ADBE Text Blur" };
+        var propMatchName = typeMap[animatorType.toLowerCase()] || "ADBE Text Opacity";
+        var animProp = animProps.addProperty(propMatchName);
+        if (animProp && value !== undefined) { try { animProp.setValue(value); } catch (e) { /* ignore */ } }
+        return JSON.stringify({ status: "success", message: "Text animator added: " + animatorType, animator: { type: animatorType, rangeStart: rangeStart, rangeEnd: rangeEnd, value: value } }, null, 2);
+    } catch (e) { return JSON.stringify({ status: "error", message: e.toString() }, null, 2); }
+}
+
+// --- getAudioWaveform ---
+function getAudioWaveform(args) {
+    try {
+        var compIndex = args.compIndex || 1;
+        var layerIndex = args.layerIndex || 1;
+        var startTime = args.startTime !== undefined ? args.startTime : 0;
+        var endTime = args.endTime !== undefined ? args.endTime : 1;
+        var samples = args.samples || 10;
+        var comp = app.project.item(compIndex);
+        if (!(comp instanceof CompItem)) throw new Error("Item " + compIndex + " is not a composition");
+        var layer = comp.layer(layerIndex);
+        if (!layer) throw new Error("Layer not found at index " + layerIndex);
+        var audio = layer.property("Audio");
+        var levelData = [];
+        var step = (endTime - startTime) / samples;
+        if (audio) {
+            var audioLevels = audio.property("Audio Levels");
+            if (audioLevels) {
+                for (var i = 0; i < samples; i++) {
+                    var t = startTime + (i * step);
+                    try { var lv = audioLevels.valueAtTime(t, true); levelData.push({ time: t, left: lv[0], right: lv[1] }); } catch (e) { levelData.push({ time: t, left: 0, right: 0 }); }
+                }
+            }
+        }
+        return JSON.stringify({ status: "success", message: "Audio waveform data approximated via Audio Levels property", note: "Full PCM waveform data is not accessible via ExtendScript.", layer: { name: layer.name, index: layer.index }, startTime: startTime, endTime: endTime, samples: samples, levelData: levelData }, null, 2);
+    } catch (e) { return JSON.stringify({ status: "error", message: e.toString() }, null, 2); }
+}
+
+// --- alignLayers ---
+function alignLayers(args) {
+    try {
+        var compIndex = args.compIndex || 1;
+        var layerIndices = args.layerIndices || [];
+        var alignTo = args.alignTo || "compHCenter";
+        if (layerIndices.length === 0) throw new Error("layerIndices array is required");
+        var comp = app.project.item(compIndex);
+        if (!(comp instanceof CompItem)) throw new Error("Item " + compIndex + " is not a composition");
+        var layers = [];
+        for (var i = 0; i < layerIndices.length; i++) { var l = comp.layer(layerIndices[i]); if (!l) throw new Error("Layer not found at index " + layerIndices[i]); layers.push(l); }
+        var compW = comp.width; var compH = comp.height;
+        var refPos = layers[0].property("Position").value;
+        var changed = [];
+        for (var j = 0; j < layers.length; j++) {
+            var pos = layers[j].property("Position").value;
+            var newX = pos[0]; var newY = pos[1];
+            if (alignTo === "compLeft") { newX = 0; } else if (alignTo === "compRight") { newX = compW; }
+            else if (alignTo === "compTop") { newY = 0; } else if (alignTo === "compBottom") { newY = compH; }
+            else if (alignTo === "compHCenter") { newX = compW / 2; } else if (alignTo === "compVCenter") { newY = compH / 2; }
+            else if (alignTo === "left" || alignTo === "right" || alignTo === "horizontalCenter") { newX = refPos[0]; }
+            else if (alignTo === "top" || alignTo === "bottom" || alignTo === "verticalCenter") { newY = refPos[1]; }
+            var newPos = pos.length === 3 ? [newX, newY, pos[2]] : [newX, newY];
+            layers[j].property("Position").setValue(newPos);
+            changed.push({ name: layers[j].name, index: layers[j].index, newPosition: newPos });
+        }
+        return JSON.stringify({ status: "success", message: "Layers aligned to " + alignTo, alignedLayers: changed }, null, 2);
+    } catch (e) { return JSON.stringify({ status: "error", message: e.toString() }, null, 2); }
+}
+
+// --- distributeKeyframes ---
+function distributeKeyframes(args) {
+    try {
+        var compIndex = args.compIndex || 1;
+        var layerIndex = args.layerIndex || 1;
+        var propertyName = args.propertyName;
+        var values = args.values || [];
+        var times = args.times || [];
+        var interpolationType = args.interpolationType || "linear";
+        if (!propertyName) throw new Error("propertyName is required");
+        if (values.length === 0) throw new Error("values array is required");
+        if (times.length === 0) throw new Error("times array is required");
+        if (values.length !== times.length) throw new Error("values and times arrays must have the same length");
+        var comp = app.project.item(compIndex);
+        if (!(comp instanceof CompItem)) throw new Error("Item " + compIndex + " is not a composition");
+        var layer = comp.layer(layerIndex);
+        if (!layer) throw new Error("Layer not found at index " + layerIndex);
+        var prop = null;
+        var transform = layer.property("Transform");
+        if (transform) { try { prop = transform.property(propertyName); } catch (e) { prop = null; } }
+        if (!prop) { try { prop = layer.property(propertyName); } catch (e) { prop = null; } }
+        if (!prop) throw new Error("Property not found: " + propertyName);
+        var addedKeys = [];
+        for (var i = 0; i < times.length; i++) { prop.setValueAtTime(times[i], values[i]); addedKeys.push({ time: times[i], value: values[i] }); }
+        if (interpolationType === "hold") {
+            for (var k = 1; k <= prop.numKeys; k++) { try { prop.setInterpolationTypeAtKey(k, KeyframeInterpolationType.HOLD); } catch (e) { /* ignore */ } }
+        } else if (interpolationType === "easy-ease") {
+            for (var k2 = 1; k2 <= prop.numKeys; k2++) { try { var ease = [new KeyframeEase(33, 33)]; prop.setTemporalEaseAtKey(k2, ease, ease); } catch (e) { /* ignore */ } }
+        }
+        return JSON.stringify({ status: "success", message: "Added " + addedKeys.length + " keyframes to " + propertyName, propertyName: propertyName, keyframes: addedKeys, interpolationType: interpolationType }, null, 2);
+    } catch (e) { return JSON.stringify({ status: "error", message: e.toString() }, null, 2); }
+}
+
+// --- setLayerStretch ---
+function setLayerStretch(args) {
+    try {
+        var compIndex = args.compIndex || 1;
+        var layerIndex = args.layerIndex || 1;
+        var stretch = args.stretch !== undefined ? args.stretch : 100;
+        var comp = app.project.item(compIndex);
+        if (!(comp instanceof CompItem)) throw new Error("Item " + compIndex + " is not a composition");
+        var layer = comp.layer(layerIndex);
+        if (!layer) throw new Error("Layer not found at index " + layerIndex);
+        layer.stretch = stretch;
+        return JSON.stringify({ status: "success", message: "Layer stretch set to " + stretch + "%", layer: { name: layer.name, index: layer.index, stretch: layer.stretch } }, null, 2);
+    } catch (e) { return JSON.stringify({ status: "error", message: e.toString() }, null, 2); }
+}
+
+// --- duplicateComposition ---
+function duplicateComposition(args) {
+    try {
+        var compIndex = args.compIndex || 1;
+        var newName = args.newName;
+        var comp = app.project.item(compIndex);
+        if (!(comp instanceof CompItem)) throw new Error("Item " + compIndex + " is not a composition");
+        var newComp = comp.duplicate();
+        if (newName) newComp.name = newName;
+        return JSON.stringify({ status: "success", message: "Composition duplicated", newComp: { name: newComp.name, id: newComp.id, width: newComp.width, height: newComp.height, duration: newComp.duration, frameRate: newComp.frameRate, numLayers: newComp.numLayers } }, null, 2);
+    } catch (e) { return JSON.stringify({ status: "error", message: e.toString() }, null, 2); }
+}
+
+// --- getRendererInfo ---
+function getRendererInfo(args) {
+    try {
+        var compIndex = args.compIndex || 1;
+        var comp = app.project.item(compIndex);
+        if (!(comp instanceof CompItem)) throw new Error("Item " + compIndex + " is not a composition");
+        var renderers = [];
+        try { var rl = comp.renderers; for (var i = 0; i < rl.length; i++) { renderers.push(rl[i]); } } catch (e) { renderers = ["ADBE Ernst", "ADBE Advanced 3d"]; }
+        return JSON.stringify({ status: "success", message: "Renderer info retrieved", currentRenderer: comp.renderer, availableRenderers: renderers, rendererDescriptions: { "ADBE Ernst": "Classic 3D renderer", "ADBE Advanced 3d": "Cinema 4D / Advanced 3D renderer" } }, null, 2);
+    } catch (e) { return JSON.stringify({ status: "error", message: e.toString() }, null, 2); }
+}
+
+// --- setRenderer ---
+function setRenderer(args) {
+    try {
+        var compIndex = args.compIndex || 1;
+        var renderer = args.renderer || "ADBE Ernst";
+        var comp = app.project.item(compIndex);
+        if (!(comp instanceof CompItem)) throw new Error("Item " + compIndex + " is not a composition");
+        var oldRenderer = comp.renderer;
+        comp.renderer = renderer;
+        return JSON.stringify({ status: "success", message: "Renderer set from '" + oldRenderer + "' to '" + renderer + "'", composition: { name: comp.name, renderer: comp.renderer } }, null, 2);
+    } catch (e) { return JSON.stringify({ status: "error", message: e.toString() }, null, 2); }
+}
+
+// --- addLutEffect ---
+function addLutEffect(args) {
+    try {
+        var compIndex = args.compIndex || 1;
+        var layerIndex = args.layerIndex || 1;
+        var lutPath = args.lutPath;
+        if (!lutPath) throw new Error("lutPath is required");
+        var lutFile = new File(lutPath);
+        if (!lutFile.exists) throw new Error("LUT file not found: " + lutPath);
+        var comp = app.project.item(compIndex);
+        if (!(comp instanceof CompItem)) throw new Error("Item " + compIndex + " is not a composition");
+        var layer = comp.layer(layerIndex);
+        if (!layer) throw new Error("Layer not found at index " + layerIndex);
+        var effect = null;
+        try { effect = layer.property("Effects").addProperty("ADBE Apply Color LUT2"); } catch (e) { effect = null; }
+        if (!effect) { try { effect = layer.property("Effects").addProperty("ADBE Apply Color LUT"); } catch (e) { effect = null; } }
+        if (!effect) throw new Error("Could not add Apply Color LUT effect");
+        var lutFileProp = null;
+        try { lutFileProp = effect.property("LUT"); } catch (e) { lutFileProp = null; }
+        if (!lutFileProp) {
+            for (var i = 1; i <= effect.numProperties; i++) { var p = effect.property(i); if (p.name.toLowerCase().indexOf("lut") !== -1) { lutFileProp = p; break; } }
+        }
+        if (lutFileProp) { lutFileProp.setValue(lutFile); }
+        return JSON.stringify({ status: "success", message: "LUT effect applied: " + lutPath, effect: { name: effect.name, matchName: effect.matchName }, lutPath: lutPath }, null, 2);
+    } catch (e) { return JSON.stringify({ status: "error", message: e.toString() }, null, 2); }
+}
+
+// --- createSlideShow ---
+function createSlideShow(args) {
+    try {
+        var compIndex = args.compIndex || 1;
+        var imagePaths = args.imagePaths || [];
+        var durationPerSlide = args.durationPerSlide !== undefined ? args.durationPerSlide : 3;
+        var transition = args.transition || "cut";
+        var transitionDuration = args.transitionDuration !== undefined ? args.transitionDuration : 0.5;
+        if (imagePaths.length === 0) throw new Error("imagePaths is required");
+        var comp = app.project.item(compIndex);
+        if (!(comp instanceof CompItem)) throw new Error("Item " + compIndex + " is not a composition");
+        var layers = [];
+        for (var i = 0; i < imagePaths.length; i++) {
+            var file = new File(imagePaths[i]);
+            if (!file.exists) throw new Error("Image file not found: " + imagePaths[i]);
+            var importOptions = new ImportOptions(file);
+            var footageItem = app.project.importFile(importOptions);
+            var slideStart = i * durationPerSlide;
+            var slideEnd = slideStart + durationPerSlide;
+            var footageLayer = comp.layers.add(footageItem);
+            footageLayer.startTime = slideStart;
+            footageLayer.outPoint = slideEnd;
+            var scaleX = (comp.width / footageLayer.width) * 100;
+            var scaleY = (comp.height / footageLayer.height) * 100;
+            var scale = Math.min(scaleX, scaleY);
+            footageLayer.property("Scale").setValue([scale, scale]);
+            footageLayer.property("Position").setValue([comp.width / 2, comp.height / 2]);
+            if (transition === "fade" && i > 0) {
+                var opacityProp = footageLayer.property("Opacity");
+                opacityProp.setValueAtTime(slideStart, 0); opacityProp.setValueAtTime(slideStart + transitionDuration, 100);
+                opacityProp.setValueAtTime(slideEnd - transitionDuration, 100); opacityProp.setValueAtTime(slideEnd, 0);
+            } else if (transition === "zoom") {
+                var scaleProp = footageLayer.property("Scale");
+                scaleProp.setValueAtTime(slideStart, [scale * 0.9, scale * 0.9]); scaleProp.setValueAtTime(slideEnd, [scale * 1.1, scale * 1.1]);
+            }
+            layers.push({ name: footageLayer.name, index: footageLayer.index, start: slideStart, end: slideEnd });
+        }
+        return JSON.stringify({ status: "success", message: "Slideshow created with " + layers.length + " slides", totalDuration: imagePaths.length * durationPerSlide, transition: transition, layers: layers }, null, 2);
+    } catch (e) { return JSON.stringify({ status: "error", message: e.toString() }, null, 2); }
+}
+
+// --- End of NEW FUNCTIONS ---
 
 // --- Bridge test function to verify communication and effects application ---
 function bridgeTestEffects(args) {
@@ -1120,6 +2267,246 @@ function executeCommand(command, args) {
                 logToPanel("Calling bridgeTestEffects function...");
                 result = bridgeTestEffects(args);
                 logToPanel("Returned from bridgeTestEffects.");
+                break;
+            case "createNullObject":
+                logToPanel("Calling createNullObject function...");
+                result = createNullObject(args);
+                logToPanel("Returned from createNullObject.");
+                break;
+            case "createCamera":
+                logToPanel("Calling createCamera function...");
+                result = createCamera(args);
+                logToPanel("Returned from createCamera.");
+                break;
+            case "createLight":
+                logToPanel("Calling createLight function...");
+                result = createLight(args);
+                logToPanel("Returned from createLight.");
+                break;
+            case "deleteLayer":
+                logToPanel("Calling deleteLayer function...");
+                result = deleteLayer(args);
+                logToPanel("Returned from deleteLayer.");
+                break;
+            case "duplicateLayer":
+                logToPanel("Calling duplicateLayer function...");
+                result = duplicateLayer(args);
+                logToPanel("Returned from duplicateLayer.");
+                break;
+            case "reorderLayer":
+                logToPanel("Calling reorderLayer function...");
+                result = reorderLayer(args);
+                logToPanel("Returned from reorderLayer.");
+                break;
+            case "renameLayer":
+                logToPanel("Calling renameLayer function...");
+                result = renameLayer(args);
+                logToPanel("Returned from renameLayer.");
+                break;
+            case "setLayerParent":
+                logToPanel("Calling setLayerParent function...");
+                result = setLayerParent(args);
+                logToPanel("Returned from setLayerParent.");
+                break;
+            case "setLayerBlendMode":
+                logToPanel("Calling setLayerBlendMode function...");
+                result = setLayerBlendMode(args);
+                logToPanel("Returned from setLayerBlendMode.");
+                break;
+            case "setLayerTrackMatte":
+                logToPanel("Calling setLayerTrackMatte function...");
+                result = setLayerTrackMatte(args);
+                logToPanel("Returned from setLayerTrackMatte.");
+                break;
+            case "setLayerFlags":
+                logToPanel("Calling setLayerFlags function...");
+                result = setLayerFlags(args);
+                logToPanel("Returned from setLayerFlags.");
+                break;
+            case "precomposeLayer":
+                logToPanel("Calling precomposeLayer function...");
+                result = precomposeLayer(args);
+                logToPanel("Returned from precomposeLayer.");
+                break;
+            case "moveLayerToTime":
+                logToPanel("Calling moveLayerToTime function...");
+                result = moveLayerToTime(args);
+                logToPanel("Returned from moveLayerToTime.");
+                break;
+            case "trimLayer":
+                logToPanel("Calling trimLayer function...");
+                result = trimLayer(args);
+                logToPanel("Returned from trimLayer.");
+                break;
+            case "splitLayer":
+                logToPanel("Calling splitLayer function...");
+                result = splitLayer(args);
+                logToPanel("Returned from splitLayer.");
+                break;
+            case "addMask":
+                logToPanel("Calling addMask function...");
+                result = addMask(args);
+                logToPanel("Returned from addMask.");
+                break;
+            case "setMaskProperties":
+                logToPanel("Calling setMaskProperties function...");
+                result = setMaskProperties(args);
+                logToPanel("Returned from setMaskProperties.");
+                break;
+            case "deleteMask":
+                logToPanel("Calling deleteMask function...");
+                result = deleteMask(args);
+                logToPanel("Returned from deleteMask.");
+                break;
+            case "importFootage":
+                logToPanel("Calling importFootage function...");
+                result = importFootage(args);
+                logToPanel("Returned from importFootage.");
+                break;
+            case "saveProject":
+                logToPanel("Calling saveProject function...");
+                result = saveProject(args);
+                logToPanel("Returned from saveProject.");
+                break;
+            case "replaceFootage":
+                logToPanel("Calling replaceFootage function...");
+                result = replaceFootage(args);
+                logToPanel("Returned from replaceFootage.");
+                break;
+            case "addToRenderQueue":
+                logToPanel("Calling addToRenderQueue function...");
+                result = addToRenderQueue(args);
+                logToPanel("Returned from addToRenderQueue.");
+                break;
+            case "renderQueue":
+                logToPanel("Calling renderQueue function...");
+                result = renderQueue(args);
+                logToPanel("Returned from renderQueue.");
+                break;
+            case "exportFrame":
+                logToPanel("Calling exportFrame function...");
+                result = exportFrame(args);
+                logToPanel("Returned from exportFrame.");
+                break;
+            case "setCompositionSettings":
+                logToPanel("Calling setCompositionSettings function...");
+                result = setCompositionSettings(args);
+                logToPanel("Returned from setCompositionSettings.");
+                break;
+            case "setWorkArea":
+                logToPanel("Calling setWorkArea function...");
+                result = setWorkArea(args);
+                logToPanel("Returned from setWorkArea.");
+                break;
+            case "trimCompToWorkArea":
+                logToPanel("Calling trimCompToWorkArea function...");
+                result = trimCompToWorkArea(args);
+                logToPanel("Returned from trimCompToWorkArea.");
+                break;
+            case "addMarker":
+                logToPanel("Calling addMarker function...");
+                result = addMarker(args);
+                logToPanel("Returned from addMarker.");
+                break;
+            case "removeEffect":
+                logToPanel("Calling removeEffect function...");
+                result = removeEffect(args);
+                logToPanel("Returned from removeEffect.");
+                break;
+            case "getEffectParams":
+                logToPanel("Calling getEffectParams function...");
+                result = getEffectParams(args);
+                logToPanel("Returned from getEffectParams.");
+                break;
+            case "setEffectParam":
+                logToPanel("Calling setEffectParam function...");
+                result = setEffectParam(args);
+                logToPanel("Returned from setEffectParam.");
+                break;
+            case "setAudioLevel":
+                logToPanel("Calling setAudioLevel function...");
+                result = setAudioLevel(args);
+                logToPanel("Returned from setAudioLevel.");
+                break;
+            case "enableTimeRemap":
+                logToPanel("Calling enableTimeRemap function...");
+                result = enableTimeRemap(args);
+                logToPanel("Returned from enableTimeRemap.");
+                break;
+            case "setTimeRemapKeyframe":
+                logToPanel("Calling setTimeRemapKeyframe function...");
+                result = setTimeRemapKeyframe(args);
+                logToPanel("Returned from setTimeRemapKeyframe.");
+                break;
+            case "executeScript":
+                logToPanel("Calling executeScript function...");
+                result = executeScript(args);
+                logToPanel("Returned from executeScript.");
+                break;
+            case "getCompFrame":
+                logToPanel("Calling getCompFrame function...");
+                result = getCompFrame(args);
+                logToPanel("Returned from getCompFrame.");
+                break;
+            case "createCaption":
+                logToPanel("Calling createCaption function...");
+                result = createCaption(args);
+                logToPanel("Returned from createCaption.");
+                break;
+            case "createZoomEffect":
+                logToPanel("Calling createZoomEffect function...");
+                result = createZoomEffect(args);
+                logToPanel("Returned from createZoomEffect.");
+                break;
+            case "addTextAnimator":
+                logToPanel("Calling addTextAnimator function...");
+                result = addTextAnimator(args);
+                logToPanel("Returned from addTextAnimator.");
+                break;
+            case "getAudioWaveform":
+                logToPanel("Calling getAudioWaveform function...");
+                result = getAudioWaveform(args);
+                logToPanel("Returned from getAudioWaveform.");
+                break;
+            case "alignLayers":
+                logToPanel("Calling alignLayers function...");
+                result = alignLayers(args);
+                logToPanel("Returned from alignLayers.");
+                break;
+            case "distributeKeyframes":
+                logToPanel("Calling distributeKeyframes function...");
+                result = distributeKeyframes(args);
+                logToPanel("Returned from distributeKeyframes.");
+                break;
+            case "setLayerStretch":
+                logToPanel("Calling setLayerStretch function...");
+                result = setLayerStretch(args);
+                logToPanel("Returned from setLayerStretch.");
+                break;
+            case "duplicateComposition":
+                logToPanel("Calling duplicateComposition function...");
+                result = duplicateComposition(args);
+                logToPanel("Returned from duplicateComposition.");
+                break;
+            case "getRendererInfo":
+                logToPanel("Calling getRendererInfo function...");
+                result = getRendererInfo(args);
+                logToPanel("Returned from getRendererInfo.");
+                break;
+            case "setRenderer":
+                logToPanel("Calling setRenderer function...");
+                result = setRenderer(args);
+                logToPanel("Returned from setRenderer.");
+                break;
+            case "addLutEffect":
+                logToPanel("Calling addLutEffect function...");
+                result = addLutEffect(args);
+                logToPanel("Returned from addLutEffect.");
+                break;
+            case "createSlideShow":
+                logToPanel("Calling createSlideShow function...");
+                result = createSlideShow(args);
+                logToPanel("Returned from createSlideShow.");
                 break;
             default:
                 result = JSON.stringify({ error: "Unknown command: " + command });

--- a/src/scripts/moveLayerToTime.jsx
+++ b/src/scripts/moveLayerToTime.jsx
@@ -1,0 +1,16 @@
+function moveLayerToTime(args) {
+    try {
+        var compIndex = args.compIndex || 1;
+        var layerIndex = args.layerIndex || 1;
+        var startTime = args.startTime !== undefined ? args.startTime : 0;
+        var comp = app.project.item(compIndex);
+        if (!(comp instanceof CompItem)) throw new Error("Item " + compIndex + " is not a composition");
+        var layer = comp.layer(layerIndex);
+        if (!layer) throw new Error("Layer not found at index " + layerIndex);
+        layer.startTime = startTime;
+        return JSON.stringify({
+            status: "success", message: "Layer moved to time " + startTime,
+            layer: { name: layer.name, index: layer.index, startTime: layer.startTime, inPoint: layer.inPoint, outPoint: layer.outPoint }
+        }, null, 2);
+    } catch (e) { return JSON.stringify({ status: "error", message: e.toString() }, null, 2); }
+}

--- a/src/scripts/precomposeLayer.jsx
+++ b/src/scripts/precomposeLayer.jsx
@@ -1,0 +1,20 @@
+function precomposeLayer(args) {
+    try {
+        var compIndex = args.compIndex || 1;
+        var layerIndices = args.layerIndices || [1];
+        var newCompName = args.newCompName || "Precomp";
+        var moveAllAttributes = args.moveAllAttributes !== undefined ? args.moveAllAttributes : true;
+        var comp = app.project.item(compIndex);
+        if (!(comp instanceof CompItem)) throw new Error("Item " + compIndex + " is not a composition");
+        // Build array (1-based)
+        var indices = [];
+        for (var i = 0; i < layerIndices.length; i++) {
+            indices.push(layerIndices[i]);
+        }
+        var newComp = comp.layers.precompose(indices, newCompName, moveAllAttributes);
+        return JSON.stringify({
+            status: "success", message: "Precomposed " + indices.length + " layer(s) into '" + newCompName + "'",
+            newComp: { name: newComp.name, id: newComp.id, width: newComp.width, height: newComp.height, duration: newComp.duration }
+        }, null, 2);
+    } catch (e) { return JSON.stringify({ status: "error", message: e.toString() }, null, 2); }
+}

--- a/src/scripts/removeEffect.jsx
+++ b/src/scripts/removeEffect.jsx
@@ -1,0 +1,29 @@
+function removeEffect(args) {
+    try {
+        var compIndex = args.compIndex || 1;
+        var layerIndex = args.layerIndex || 1;
+        var effectName = args.effectName;
+        var effectIndex = args.effectIndex;
+        var comp = app.project.item(compIndex);
+        if (!(comp instanceof CompItem)) throw new Error("Item " + compIndex + " is not a composition");
+        var layer = comp.layer(layerIndex);
+        if (!layer) throw new Error("Layer not found at index " + layerIndex);
+        var effects = layer.property("Effects");
+        if (!effects) throw new Error("No effects on this layer");
+        var effect = null;
+        if (effectIndex !== undefined && effectIndex !== null) {
+            effect = effects.property(effectIndex);
+        } else if (effectName) {
+            for (var i = 1; i <= effects.numProperties; i++) {
+                if (effects.property(i).name === effectName) {
+                    effect = effects.property(i);
+                    break;
+                }
+            }
+        }
+        if (!effect) throw new Error("Effect not found: " + (effectName || "index " + effectIndex));
+        var removedName = effect.name;
+        effect.remove();
+        return JSON.stringify({ status: "success", message: "Effect removed: " + removedName }, null, 2);
+    } catch (e) { return JSON.stringify({ status: "error", message: e.toString() }, null, 2); }
+}

--- a/src/scripts/renameLayer.jsx
+++ b/src/scripts/renameLayer.jsx
@@ -1,0 +1,17 @@
+function renameLayer(args) {
+    try {
+        var compIndex = args.compIndex || 1;
+        var layerIndex = args.layerIndex || 1;
+        var newName = args.newName || "Layer";
+        var comp = app.project.item(compIndex);
+        if (!(comp instanceof CompItem)) throw new Error("Item " + compIndex + " is not a composition");
+        var layer = comp.layer(layerIndex);
+        if (!layer) throw new Error("Layer not found at index " + layerIndex);
+        var oldName = layer.name;
+        layer.name = newName;
+        return JSON.stringify({
+            status: "success", message: "Layer renamed from '" + oldName + "' to '" + newName + "'",
+            layer: { name: layer.name, index: layer.index }
+        }, null, 2);
+    } catch (e) { return JSON.stringify({ status: "error", message: e.toString() }, null, 2); }
+}

--- a/src/scripts/renderQueue.jsx
+++ b/src/scripts/renderQueue.jsx
@@ -1,0 +1,28 @@
+function renderQueue(args) {
+    try {
+        var action = args.action || "status";
+        var rq = app.project.renderQueue;
+        if (action === "start") {
+            rq.render();
+            return JSON.stringify({ status: "success", message: "Render started", action: "start" }, null, 2);
+        } else if (action === "stop") {
+            rq.stopRendering();
+            return JSON.stringify({ status: "success", message: "Render stopped", action: "stop" }, null, 2);
+        } else if (action === "clear") {
+            // Remove all queued items
+            var removed = 0;
+            for (var i = rq.numItems; i >= 1; i--) {
+                try { rq.item(i).remove(); removed++; } catch (e) { /* some items may not be removable */ }
+            }
+            return JSON.stringify({ status: "success", message: "Cleared " + removed + " items from render queue", action: "clear" }, null, 2);
+        } else {
+            // status
+            var items = [];
+            for (var j = 1; j <= rq.numItems; j++) {
+                var item = rq.item(j);
+                items.push({ index: j, comp: item.comp ? item.comp.name : "Unknown", status: item.status.toString() });
+            }
+            return JSON.stringify({ status: "success", action: "status", numItems: rq.numItems, items: items }, null, 2);
+        }
+    } catch (e) { return JSON.stringify({ status: "error", message: e.toString() }, null, 2); }
+}

--- a/src/scripts/reorderLayer.jsx
+++ b/src/scripts/reorderLayer.jsx
@@ -1,0 +1,16 @@
+function reorderLayer(args) {
+    try {
+        var compIndex = args.compIndex || 1;
+        var layerIndex = args.layerIndex || 1;
+        var newIndex = args.newIndex || 1;
+        var comp = app.project.item(compIndex);
+        if (!(comp instanceof CompItem)) throw new Error("Item " + compIndex + " is not a composition");
+        var layer = comp.layer(layerIndex);
+        if (!layer) throw new Error("Layer not found at index " + layerIndex);
+        layer.moveToIndex(newIndex);
+        return JSON.stringify({
+            status: "success", message: "Layer moved to index " + newIndex,
+            layer: { name: layer.name, index: layer.index }
+        }, null, 2);
+    } catch (e) { return JSON.stringify({ status: "error", message: e.toString() }, null, 2); }
+}

--- a/src/scripts/replaceFootage.jsx
+++ b/src/scripts/replaceFootage.jsx
@@ -1,0 +1,17 @@
+function replaceFootage(args) {
+    try {
+        var itemIndex = args.itemIndex || 1;
+        var newFilePath = args.newFilePath;
+        if (!newFilePath) throw new Error("newFilePath is required");
+        var item = app.project.item(itemIndex);
+        if (!item) throw new Error("Item not found at index " + itemIndex);
+        if (!(item instanceof FootageItem)) throw new Error("Item at index " + itemIndex + " is not a footage item");
+        var newFile = new File(newFilePath);
+        if (!newFile.exists) throw new Error("File not found: " + newFilePath);
+        item.replace(newFile);
+        return JSON.stringify({
+            status: "success", message: "Footage replaced with: " + newFilePath,
+            footage: { name: item.name, id: item.id }
+        }, null, 2);
+    } catch (e) { return JSON.stringify({ status: "error", message: e.toString() }, null, 2); }
+}

--- a/src/scripts/saveProject.jsx
+++ b/src/scripts/saveProject.jsx
@@ -1,0 +1,14 @@
+function saveProject(args) {
+    try {
+        var filePath = args.filePath;
+        if (filePath) {
+            var file = new File(filePath);
+            app.project.save(file);
+            return JSON.stringify({ status: "success", message: "Project saved to: " + filePath, path: filePath }, null, 2);
+        } else {
+            app.project.save();
+            var savedPath = app.project.file ? app.project.file.fsName : "Untitled";
+            return JSON.stringify({ status: "success", message: "Project saved", path: savedPath }, null, 2);
+        }
+    } catch (e) { return JSON.stringify({ status: "error", message: e.toString() }, null, 2); }
+}

--- a/src/scripts/setAudioLevel.jsx
+++ b/src/scripts/setAudioLevel.jsx
@@ -1,0 +1,23 @@
+function setAudioLevel(args) {
+    try {
+        var compIndex = args.compIndex || 1;
+        var layerIndex = args.layerIndex || 1;
+        var level = args.level !== undefined ? args.level : 0;
+        var timeInSeconds = args.timeInSeconds;
+        var comp = app.project.item(compIndex);
+        if (!(comp instanceof CompItem)) throw new Error("Item " + compIndex + " is not a composition");
+        var layer = comp.layer(layerIndex);
+        if (!layer) throw new Error("Layer not found at index " + layerIndex);
+        var audio = layer.property("Audio");
+        if (!audio) throw new Error("Layer does not have audio properties");
+        var audioLevels = audio.property("Audio Levels");
+        if (!audioLevels) throw new Error("Audio Levels property not found");
+        if (timeInSeconds !== undefined && timeInSeconds !== null) {
+            audioLevels.setValueAtTime(timeInSeconds, [level, level]);
+            return JSON.stringify({ status: "success", message: "Audio level keyframe set at " + timeInSeconds + "s: " + level + " dB", level: level, time: timeInSeconds }, null, 2);
+        } else {
+            audioLevels.setValue([level, level]);
+            return JSON.stringify({ status: "success", message: "Audio level set to " + level + " dB", level: level }, null, 2);
+        }
+    } catch (e) { return JSON.stringify({ status: "error", message: e.toString() }, null, 2); }
+}

--- a/src/scripts/setCompositionSettings.jsx
+++ b/src/scripts/setCompositionSettings.jsx
@@ -1,0 +1,23 @@
+function setCompositionSettings(args) {
+    try {
+        var compIndex = args.compIndex || 1;
+        var comp = app.project.item(compIndex);
+        if (!(comp instanceof CompItem)) throw new Error("Item " + compIndex + " is not a composition");
+        var changed = [];
+        if (args.name !== undefined) { comp.name = args.name; changed.push("name"); }
+        if (args.width !== undefined) { comp.width = args.width; changed.push("width"); }
+        if (args.height !== undefined) { comp.height = args.height; changed.push("height"); }
+        if (args.frameRate !== undefined) { comp.frameRate = args.frameRate; changed.push("frameRate"); }
+        if (args.duration !== undefined) { comp.duration = args.duration; changed.push("duration"); }
+        if (args.pixelAspect !== undefined) { comp.pixelAspect = args.pixelAspect; changed.push("pixelAspect"); }
+        if (args.bgColor !== undefined) {
+            var bg = args.bgColor;
+            comp.bgColor = [bg.r !== undefined ? bg.r : bg[0], bg.g !== undefined ? bg.g : bg[1], bg.b !== undefined ? bg.b : bg[2]];
+            changed.push("bgColor");
+        }
+        return JSON.stringify({
+            status: "success", message: "Composition settings updated: " + changed.join(", "),
+            composition: { name: comp.name, width: comp.width, height: comp.height, frameRate: comp.frameRate, duration: comp.duration, pixelAspect: comp.pixelAspect }
+        }, null, 2);
+    } catch (e) { return JSON.stringify({ status: "error", message: e.toString() }, null, 2); }
+}

--- a/src/scripts/setEffectParam.jsx
+++ b/src/scripts/setEffectParam.jsx
@@ -1,0 +1,42 @@
+function setEffectParam(args) {
+    try {
+        var compIndex = args.compIndex || 1;
+        var layerIndex = args.layerIndex || 1;
+        var effectName = args.effectName;
+        var paramName = args.paramName;
+        var value = args.value;
+        if (!effectName) throw new Error("effectName is required");
+        if (!paramName) throw new Error("paramName is required");
+        if (value === undefined) throw new Error("value is required");
+        var comp = app.project.item(compIndex);
+        if (!(comp instanceof CompItem)) throw new Error("Item " + compIndex + " is not a composition");
+        var layer = comp.layer(layerIndex);
+        if (!layer) throw new Error("Layer not found at index " + layerIndex);
+        var effects = layer.property("Effects");
+        if (!effects) throw new Error("No effects on this layer");
+        var effect = null;
+        for (var i = 1; i <= effects.numProperties; i++) {
+            if (effects.property(i).name === effectName) {
+                effect = effects.property(i);
+                break;
+            }
+        }
+        if (!effect) throw new Error("Effect not found: " + effectName);
+        var param = null;
+        try { param = effect.property(paramName); } catch (e) { /* try by name */ }
+        if (!param) {
+            for (var j = 1; j <= effect.numProperties; j++) {
+                if (effect.property(j).name === paramName) {
+                    param = effect.property(j);
+                    break;
+                }
+            }
+        }
+        if (!param) throw new Error("Parameter not found: " + paramName);
+        param.setValue(value);
+        return JSON.stringify({
+            status: "success", message: "Effect parameter set: " + paramName + " = " + JSON.stringify(value),
+            effect: effectName, param: paramName, value: value
+        }, null, 2);
+    } catch (e) { return JSON.stringify({ status: "error", message: e.toString() }, null, 2); }
+}

--- a/src/scripts/setLayerBlendMode.jsx
+++ b/src/scripts/setLayerBlendMode.jsx
@@ -1,0 +1,56 @@
+function setLayerBlendMode(args) {
+    try {
+        var compIndex = args.compIndex || 1;
+        var layerIndex = args.layerIndex || 1;
+        var blendModeStr = args.blendMode || "NORMAL";
+        var comp = app.project.item(compIndex);
+        if (!(comp instanceof CompItem)) throw new Error("Item " + compIndex + " is not a composition");
+        var layer = comp.layer(layerIndex);
+        if (!layer) throw new Error("Layer not found at index " + layerIndex);
+        var blendModeMap = {
+            "NORMAL": BlendingMode.NORMAL,
+            "DISSOLVE": BlendingMode.DISSOLVE,
+            "DANCING_DISSOLVE": BlendingMode.DANCING_DISSOLVE,
+            "DARKEN": BlendingMode.DARKEN,
+            "MULTIPLY": BlendingMode.MULTIPLY,
+            "COLOR_BURN": BlendingMode.COLOR_BURN,
+            "CLASSIC_COLOR_BURN": BlendingMode.CLASSIC_COLOR_BURN,
+            "LINEAR_BURN": BlendingMode.LINEAR_BURN,
+            "DARKER_COLOR": BlendingMode.DARKER_COLOR,
+            "ADD": BlendingMode.ADD,
+            "LIGHTEN": BlendingMode.LIGHTEN,
+            "SCREEN": BlendingMode.SCREEN,
+            "COLOR_DODGE": BlendingMode.COLOR_DODGE,
+            "CLASSIC_COLOR_DODGE": BlendingMode.CLASSIC_COLOR_DODGE,
+            "LINEAR_DODGE": BlendingMode.LINEAR_DODGE,
+            "LIGHTER_COLOR": BlendingMode.LIGHTER_COLOR,
+            "OVERLAY": BlendingMode.OVERLAY,
+            "SOFT_LIGHT": BlendingMode.SOFT_LIGHT,
+            "HARD_LIGHT": BlendingMode.HARD_LIGHT,
+            "LINEAR_LIGHT": BlendingMode.LINEAR_LIGHT,
+            "VIVID_LIGHT": BlendingMode.VIVID_LIGHT,
+            "PIN_LIGHT": BlendingMode.PIN_LIGHT,
+            "HARD_MIX": BlendingMode.HARD_MIX,
+            "DIFFERENCE": BlendingMode.DIFFERENCE,
+            "CLASSIC_DIFFERENCE": BlendingMode.CLASSIC_DIFFERENCE,
+            "EXCLUSION": BlendingMode.EXCLUSION,
+            "HUE": BlendingMode.HUE,
+            "SATURATION": BlendingMode.SATURATION,
+            "COLOR": BlendingMode.COLOR,
+            "LUMINOSITY": BlendingMode.LUMINOSITY,
+            "STENCIL_ALPHA": BlendingMode.STENCIL_ALPHA,
+            "STENCIL_LUMA": BlendingMode.STENCIL_LUMA,
+            "SILHOUETTE_ALPHA": BlendingMode.SILHOUETTE_ALPHA,
+            "SILHOUETTE_LUMA": BlendingMode.SILHOUETTE_LUMA,
+            "ALPHA_ADD": BlendingMode.ALPHA_ADD,
+            "LUMINESCENT_PREMUL": BlendingMode.LUMINESCENT_PREMUL
+        };
+        var mode = blendModeMap[blendModeStr.toUpperCase()];
+        if (mode === undefined) throw new Error("Unknown blend mode: " + blendModeStr);
+        layer.blendingMode = mode;
+        return JSON.stringify({
+            status: "success", message: "Blend mode set to " + blendModeStr,
+            layer: { name: layer.name, index: layer.index, blendMode: blendModeStr }
+        }, null, 2);
+    } catch (e) { return JSON.stringify({ status: "error", message: e.toString() }, null, 2); }
+}

--- a/src/scripts/setLayerFlags.jsx
+++ b/src/scripts/setLayerFlags.jsx
@@ -1,0 +1,29 @@
+function setLayerFlags(args) {
+    try {
+        var compIndex = args.compIndex || 1;
+        var layerIndex = args.layerIndex || 1;
+        var flags = args.flags || {};
+        var comp = app.project.item(compIndex);
+        if (!(comp instanceof CompItem)) throw new Error("Item " + compIndex + " is not a composition");
+        var layer = comp.layer(layerIndex);
+        if (!layer) throw new Error("Layer not found at index " + layerIndex);
+        var changed = [];
+        if (flags.solo !== undefined) { layer.solo = flags.solo; changed.push("solo=" + flags.solo); }
+        if (flags.shy !== undefined) { layer.shy = flags.shy; changed.push("shy=" + flags.shy); }
+        if (flags.locked !== undefined) { layer.locked = flags.locked; changed.push("locked=" + flags.locked); }
+        if (flags.motionBlur !== undefined) { layer.motionBlur = flags.motionBlur; changed.push("motionBlur=" + flags.motionBlur); }
+        if (flags.enable3D !== undefined) { layer.threeDLayer = flags.enable3D; changed.push("threeDLayer=" + flags.enable3D); }
+        if (flags.adjustmentLayer !== undefined) { layer.adjustmentLayer = flags.adjustmentLayer; changed.push("adjustmentLayer=" + flags.adjustmentLayer); }
+        if (flags.collapseTransformation !== undefined) { layer.collapseTransformation = flags.collapseTransformation; changed.push("collapseTransformation=" + flags.collapseTransformation); }
+        if (flags.frameBlending !== undefined) { layer.frameBlending = flags.frameBlending; changed.push("frameBlending=" + flags.frameBlending); }
+        if (flags.frameBlendingType !== undefined) {
+            var fbTypeMap = { "FRAME_MIX": FrameBlendingType.FRAME_MIX, "PIXEL_MOTION": FrameBlendingType.PIXEL_MOTION };
+            var fbType = fbTypeMap[flags.frameBlendingType];
+            if (fbType !== undefined) { layer.frameBlendingType = fbType; changed.push("frameBlendingType=" + flags.frameBlendingType); }
+        }
+        return JSON.stringify({
+            status: "success", message: "Layer flags updated: " + changed.join(", "),
+            layer: { name: layer.name, index: layer.index, changed: changed }
+        }, null, 2);
+    } catch (e) { return JSON.stringify({ status: "error", message: e.toString() }, null, 2); }
+}

--- a/src/scripts/setLayerParent.jsx
+++ b/src/scripts/setLayerParent.jsx
@@ -1,0 +1,23 @@
+function setLayerParent(args) {
+    try {
+        var compIndex = args.compIndex || 1;
+        var layerIndex = args.layerIndex || 1;
+        var parentLayerIndex = args.parentLayerIndex !== undefined ? args.parentLayerIndex : 0;
+        var comp = app.project.item(compIndex);
+        if (!(comp instanceof CompItem)) throw new Error("Item " + compIndex + " is not a composition");
+        var layer = comp.layer(layerIndex);
+        if (!layer) throw new Error("Layer not found at index " + layerIndex);
+        if (parentLayerIndex === 0 || parentLayerIndex === null) {
+            layer.parent = null;
+            return JSON.stringify({ status: "success", message: "Layer parent cleared", layer: { name: layer.name, index: layer.index, parent: null } }, null, 2);
+        } else {
+            var parentLayer = comp.layer(parentLayerIndex);
+            if (!parentLayer) throw new Error("Parent layer not found at index " + parentLayerIndex);
+            layer.parent = parentLayer;
+            return JSON.stringify({
+                status: "success", message: "Layer parent set",
+                layer: { name: layer.name, index: layer.index, parent: { name: parentLayer.name, index: parentLayer.index } }
+            }, null, 2);
+        }
+    } catch (e) { return JSON.stringify({ status: "error", message: e.toString() }, null, 2); }
+}

--- a/src/scripts/setLayerStretch.jsx
+++ b/src/scripts/setLayerStretch.jsx
@@ -1,0 +1,16 @@
+function setLayerStretch(args) {
+    try {
+        var compIndex = args.compIndex || 1;
+        var layerIndex = args.layerIndex || 1;
+        var stretch = args.stretch !== undefined ? args.stretch : 100;
+        var comp = app.project.item(compIndex);
+        if (!(comp instanceof CompItem)) throw new Error("Item " + compIndex + " is not a composition");
+        var layer = comp.layer(layerIndex);
+        if (!layer) throw new Error("Layer not found at index " + layerIndex);
+        layer.stretch = stretch;
+        return JSON.stringify({
+            status: "success", message: "Layer stretch set to " + stretch + "%",
+            layer: { name: layer.name, index: layer.index, stretch: layer.stretch }
+        }, null, 2);
+    } catch (e) { return JSON.stringify({ status: "error", message: e.toString() }, null, 2); }
+}

--- a/src/scripts/setLayerTrackMatte.jsx
+++ b/src/scripts/setLayerTrackMatte.jsx
@@ -1,0 +1,25 @@
+function setLayerTrackMatte(args) {
+    try {
+        var compIndex = args.compIndex || 1;
+        var layerIndex = args.layerIndex || 1;
+        var matteTypeStr = args.matteType || "NONE";
+        var comp = app.project.item(compIndex);
+        if (!(comp instanceof CompItem)) throw new Error("Item " + compIndex + " is not a composition");
+        var layer = comp.layer(layerIndex);
+        if (!layer) throw new Error("Layer not found at index " + layerIndex);
+        var matteMap = {
+            "NONE": TrackMatteType.NO_TRACK_MATTE,
+            "ALPHA": TrackMatteType.ALPHA,
+            "ALPHA_INVERTED": TrackMatteType.ALPHA_INVERTED,
+            "LUMA": TrackMatteType.LUMA,
+            "LUMA_INVERTED": TrackMatteType.LUMA_INVERTED
+        };
+        var matteType = matteMap[matteTypeStr.toUpperCase()];
+        if (matteType === undefined) throw new Error("Unknown matte type: " + matteTypeStr);
+        layer.trackMatteType = matteType;
+        return JSON.stringify({
+            status: "success", message: "Track matte set to " + matteTypeStr,
+            layer: { name: layer.name, index: layer.index, matteType: matteTypeStr }
+        }, null, 2);
+    } catch (e) { return JSON.stringify({ status: "error", message: e.toString() }, null, 2); }
+}

--- a/src/scripts/setMaskProperties.jsx
+++ b/src/scripts/setMaskProperties.jsx
@@ -1,0 +1,50 @@
+function setMaskProperties(args) {
+    try {
+        var compIndex = args.compIndex || 1;
+        var layerIndex = args.layerIndex || 1;
+        var maskIndex = args.maskIndex || 1;
+        var feather = args.feather;
+        var opacity = args.opacity;
+        var expansion = args.expansion;
+        var inverted = args.inverted;
+        var modeStr = args.mode;
+        var comp = app.project.item(compIndex);
+        if (!(comp instanceof CompItem)) throw new Error("Item " + compIndex + " is not a composition");
+        var layer = comp.layer(layerIndex);
+        if (!layer) throw new Error("Layer not found at index " + layerIndex);
+        var maskGroup = layer.property("Masks");
+        var mask = maskGroup.property(maskIndex);
+        if (!mask) throw new Error("Mask not found at index " + maskIndex);
+        var changed = [];
+        if (feather !== undefined && feather !== null) {
+            var featherProp = mask.property("Mask Feather");
+            if (featherProp) { featherProp.setValue(feather instanceof Array ? feather : [feather, feather]); changed.push("feather"); }
+        }
+        if (opacity !== undefined && opacity !== null) {
+            var opacityProp = mask.property("Mask Opacity");
+            if (opacityProp) { opacityProp.setValue(opacity); changed.push("opacity"); }
+        }
+        if (expansion !== undefined && expansion !== null) {
+            var expansionProp = mask.property("Mask Expansion");
+            if (expansionProp) { expansionProp.setValue(expansion); changed.push("expansion"); }
+        }
+        if (inverted !== undefined) { mask.inverted = inverted; changed.push("inverted"); }
+        if (modeStr !== undefined) {
+            var modeMap = {
+                "NONE": MaskMode.NONE,
+                "ADD": MaskMode.ADD,
+                "SUBTRACT": MaskMode.SUBTRACT,
+                "INTERSECT": MaskMode.INTERSECT,
+                "LIGHTEN": MaskMode.LIGHTEN,
+                "DARKEN": MaskMode.DARKEN,
+                "DIFFERENCE": MaskMode.DIFFERENCE
+            };
+            var mode = modeMap[modeStr.toUpperCase()];
+            if (mode !== undefined) { mask.maskMode = mode; changed.push("mode"); }
+        }
+        return JSON.stringify({
+            status: "success", message: "Mask properties updated: " + changed.join(", "),
+            mask: { index: maskIndex, changed: changed }
+        }, null, 2);
+    } catch (e) { return JSON.stringify({ status: "error", message: e.toString() }, null, 2); }
+}

--- a/src/scripts/setRenderer.jsx
+++ b/src/scripts/setRenderer.jsx
@@ -1,0 +1,14 @@
+function setRenderer(args) {
+    try {
+        var compIndex = args.compIndex || 1;
+        var renderer = args.renderer || "ADBE Ernst";
+        var comp = app.project.item(compIndex);
+        if (!(comp instanceof CompItem)) throw new Error("Item " + compIndex + " is not a composition");
+        var oldRenderer = comp.renderer;
+        comp.renderer = renderer;
+        return JSON.stringify({
+            status: "success", message: "Renderer set from '" + oldRenderer + "' to '" + renderer + "'",
+            composition: { name: comp.name, renderer: comp.renderer }
+        }, null, 2);
+    } catch (e) { return JSON.stringify({ status: "error", message: e.toString() }, null, 2); }
+}

--- a/src/scripts/setTimeRemapKeyframe.jsx
+++ b/src/scripts/setTimeRemapKeyframe.jsx
@@ -1,0 +1,22 @@
+function setTimeRemapKeyframe(args) {
+    try {
+        var compIndex = args.compIndex || 1;
+        var layerIndex = args.layerIndex || 1;
+        var timeInSeconds = args.timeInSeconds !== undefined ? args.timeInSeconds : 0;
+        var remapValue = args.remapValue !== undefined ? args.remapValue : 0;
+        var comp = app.project.item(compIndex);
+        if (!(comp instanceof CompItem)) throw new Error("Item " + compIndex + " is not a composition");
+        var layer = comp.layer(layerIndex);
+        if (!layer) throw new Error("Layer not found at index " + layerIndex);
+        if (!layer.timeRemapEnabled) {
+            layer.timeRemapEnabled = true;
+        }
+        var timeRemap = layer.property("Time Remap");
+        if (!timeRemap) throw new Error("Time Remap property not found");
+        timeRemap.setValueAtTime(timeInSeconds, remapValue);
+        return JSON.stringify({
+            status: "success", message: "Time remap keyframe set at " + timeInSeconds + "s to " + remapValue,
+            timeInSeconds: timeInSeconds, remapValue: remapValue
+        }, null, 2);
+    } catch (e) { return JSON.stringify({ status: "error", message: e.toString() }, null, 2); }
+}

--- a/src/scripts/setWorkArea.jsx
+++ b/src/scripts/setWorkArea.jsx
@@ -1,0 +1,17 @@
+function setWorkArea(args) {
+    try {
+        var compIndex = args.compIndex || 1;
+        var workAreaStart = args.workAreaStart !== undefined ? args.workAreaStart : 0;
+        var workAreaDuration = args.workAreaDuration;
+        var comp = app.project.item(compIndex);
+        if (!(comp instanceof CompItem)) throw new Error("Item " + compIndex + " is not a composition");
+        comp.workAreaStart = workAreaStart;
+        if (workAreaDuration !== undefined && workAreaDuration !== null) {
+            comp.workAreaDuration = workAreaDuration;
+        }
+        return JSON.stringify({
+            status: "success", message: "Work area set",
+            workArea: { start: comp.workAreaStart, duration: comp.workAreaDuration, end: comp.workAreaStart + comp.workAreaDuration }
+        }, null, 2);
+    } catch (e) { return JSON.stringify({ status: "error", message: e.toString() }, null, 2); }
+}

--- a/src/scripts/splitLayer.jsx
+++ b/src/scripts/splitLayer.jsx
@@ -1,0 +1,29 @@
+function splitLayer(args) {
+    try {
+        var compIndex = args.compIndex || 1;
+        var layerIndex = args.layerIndex || 1;
+        var splitTime = args.splitTime !== undefined ? args.splitTime : 1;
+        var comp = app.project.item(compIndex);
+        if (!(comp instanceof CompItem)) throw new Error("Item " + compIndex + " is not a composition");
+        var layer = comp.layer(layerIndex);
+        if (!layer) throw new Error("Layer not found at index " + layerIndex);
+        if (splitTime <= layer.inPoint || splitTime >= layer.outPoint) {
+            throw new Error("splitTime " + splitTime + " must be between layer inPoint " + layer.inPoint + " and outPoint " + layer.outPoint);
+        }
+        var origOutPoint = layer.outPoint;
+        // Duplicate the layer
+        var newLayer = layer.duplicate();
+        // Trim original to split time
+        layer.outPoint = splitTime;
+        // Trim new layer to start at split time
+        newLayer.inPoint = splitTime;
+        newLayer.outPoint = origOutPoint;
+        // Move new layer below original
+        newLayer.moveAfter(layer);
+        return JSON.stringify({
+            status: "success", message: "Layer split at " + splitTime,
+            originalLayer: { name: layer.name, index: layer.index, inPoint: layer.inPoint, outPoint: layer.outPoint },
+            newLayer: { name: newLayer.name, index: newLayer.index, inPoint: newLayer.inPoint, outPoint: newLayer.outPoint }
+        }, null, 2);
+    } catch (e) { return JSON.stringify({ status: "error", message: e.toString() }, null, 2); }
+}

--- a/src/scripts/trimCompToWorkArea.jsx
+++ b/src/scripts/trimCompToWorkArea.jsx
@@ -1,0 +1,22 @@
+function trimCompToWorkArea(args) {
+    try {
+        var compIndex = args.compIndex || 1;
+        var comp = app.project.item(compIndex);
+        if (!(comp instanceof CompItem)) throw new Error("Item " + compIndex + " is not a composition");
+        var waStart = comp.workAreaStart;
+        var waDuration = comp.workAreaDuration;
+        // Shift layers if work area doesn't start at 0
+        if (waStart > 0) {
+            for (var i = 1; i <= comp.numLayers; i++) {
+                var layer = comp.layer(i);
+                layer.startTime = layer.startTime - waStart;
+            }
+        }
+        comp.duration = waDuration;
+        comp.workAreaStart = 0;
+        return JSON.stringify({
+            status: "success", message: "Composition trimmed to work area",
+            composition: { name: comp.name, duration: comp.duration, workAreaStart: comp.workAreaStart, workAreaDuration: comp.workAreaDuration }
+        }, null, 2);
+    } catch (e) { return JSON.stringify({ status: "error", message: e.toString() }, null, 2); }
+}

--- a/src/scripts/trimLayer.jsx
+++ b/src/scripts/trimLayer.jsx
@@ -1,0 +1,18 @@
+function trimLayer(args) {
+    try {
+        var compIndex = args.compIndex || 1;
+        var layerIndex = args.layerIndex || 1;
+        var inPoint = args.inPoint;
+        var outPoint = args.outPoint;
+        var comp = app.project.item(compIndex);
+        if (!(comp instanceof CompItem)) throw new Error("Item " + compIndex + " is not a composition");
+        var layer = comp.layer(layerIndex);
+        if (!layer) throw new Error("Layer not found at index " + layerIndex);
+        if (inPoint !== undefined && inPoint !== null) layer.inPoint = inPoint;
+        if (outPoint !== undefined && outPoint !== null) layer.outPoint = outPoint;
+        return JSON.stringify({
+            status: "success", message: "Layer trimmed",
+            layer: { name: layer.name, index: layer.index, inPoint: layer.inPoint, outPoint: layer.outPoint }
+        }, null, 2);
+    } catch (e) { return JSON.stringify({ status: "error", message: e.toString() }, null, 2); }
+}


### PR DESCRIPTION
## Summary

- Expands the MCP from 13 tools to **65 tools**, covering the full range of what a professional After Effects editor can do
- Adds 48 new ExtendScript files in `src/scripts/` — one per operation — keeping each script focused and maintainable
- Updates `mcp-bridge-auto.jsx` with all new function definitions and switch-case dispatch entries
- Switches build toolchain from `tsc` to `esbuild` to eliminate OOM errors on large TypeScript projects

## New tools by category

| Category | New tools |
|---|---|
| **Layer creation** | `create-null-object`, `create-camera`, `create-light`, `create-caption`, `create-slide-show` |
| **Layer management** | `delete-layer`, `duplicate-layer`, `reorder-layer`, `rename-layer`, `set-layer-parent`, `set-layer-blend-mode`, `set-layer-track-matte`, `set-layer-flags`, `set-layer-stretch`, `precompose-layer`, `move-layer-to-time`, `trim-layer`, `split-layer` |
| **Text & shapes** | `create-text-layer`, `create-shape-layer`, `create-solid-layer`, `set-layer-properties`, `add-text-animator` |
| **Masks** | `add-mask`, `set-mask-properties`, `delete-mask` |
| **Effects** | `remove-effect`, `get-effect-params`, `set-effect-param`, `add-lut-effect` |
| **Animation** | `create-zoom-effect`, `distribute-keyframes`, `enable-time-remap`, `set-time-remap-keyframe`, `set-audio-level` |
| **Composition** | `set-composition-settings`, `set-work-area`, `trim-comp-to-work-area`, `duplicate-composition`, `set-renderer`, `get-renderer-info`, `add-marker` |
| **Project** | `import-footage`, `save-project`, `replace-footage` |
| **Render / Export** | `add-to-render-queue`, `render-queue`, `export-frame`, `get-comp-frame` |
| **Audio** | `set-audio-level`, `get-audio-waveform` |
| **Alignment** | `align-layers`, `distribute-keyframes` |
| **Power tool** | `execute-script` — run arbitrary ExtendScript for anything not covered above |

## Test plan

- [x] Open After Effects with the updated `mcp-bridge-auto.jsx` panel
- [x] Verify panel loads without errors (Auto-run ON)
- [x] Test a layer creation tool (e.g. `create-text-layer`)
- [x] Test a layer management tool (e.g. `duplicate-layer`, `set-layer-blend-mode`)
- [x] Test `export-frame` to confirm single-frame PNG export works
- [x] Test `execute-script` with a simple ExtendScript snippet
- [x] Run `npm run build` to confirm esbuild compiles successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)