### PR TITLE
feat: add general-purpose layer, effect, render, text & introspection tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,7 @@ You can animate layers with:
 | `save-frame`                | Render a single frame to a PNG file    |
 | `save-project`              | Save the current project               |
 | `get-layer-details`         | Inspect a layer (effects, blend, parent, 3D) |
+| `delete-composition`        | Delete a composition from the project  |
 
 > ℹ️ Output format for `render-video` is determined by the chosen output module template (or the default one); on some installs the default is H.264 (.mp4). `save-frame` is handy for letting an AI assistant inspect the rendered result.
 

--- a/README.md
+++ b/README.md
@@ -55,8 +55,20 @@
 
 ### 🌀 Animation Capabilities
 - **Set keyframes** for layer properties (Position, Scale, Rotation, Opacity, etc.)
+- **Apply easing** (easy ease / ease in / ease out) to existing keyframes
 - **Apply expressions** to layer properties for dynamic animations
 - **Batch set properties** across multiple layers at once
+- **Trim Paths** on shape layers, including animated "draw-on"
+- **Text animators** with range selectors for per-character animation
+
+### ✨ Effects, Rendering & Project
+- **Apply, remove, and reorder effects** on a layer
+- **Create lights** (parallel, spot, point, ambient) and **reorder layers** in the stack
+- **Set or clear a layer's parent** for rigging
+- **Import footage** (image / video / audio) and optionally add it to a comp
+- **Precompose** layers into a nested composition
+- **Render to a video file** via the render queue, or **capture a single frame to PNG** (so the result can be inspected)
+- **Inspect layer details** (effects, blend mode, parent, 3D, timing) and **save the project**
 
 ## ⚙️ Setup Instructions
 
@@ -215,6 +227,26 @@ You can animate layers with:
 | `duplicateLayer`            | Duplicate a layer                     |
 | `deleteLayer`               | Delete a layer                        |
 | `setLayerMask`              | Create/modify layer masks             |
+| `move-layer`                | Reorder a layer (front/back/before/after/to-index) |
+| `set-parent`                | Set or clear a layer's parent          |
+| `create-null`               | Create a null object layer             |
+| `set-3d-layer`              | Toggle a layer's 3D switch             |
+| `set-blend-mode`            | Set a layer's blending mode            |
+| `set-track-matte`           | Set/clear a track matte (optionally to a specific layer) |
+| `remove-effect`             | Remove an effect from a layer          |
+| `reorder-effect`            | Reorder an effect in the effect stack  |
+| `create-light`              | Create a light layer                   |
+| `apply-trim-paths`          | Add Trim Paths to a shape (with draw-on) |
+| `add-text-animator`         | Add a text animator (per-character)    |
+| `set-keyframe-ease`         | Apply easing to a property's keyframes |
+| `import-footage`            | Import a file into the project         |
+| `precompose`                | Precompose layers into a nested comp   |
+| `render-video`              | Render a composition to a video file   |
+| `save-frame`                | Render a single frame to a PNG file    |
+| `save-project`              | Save the current project               |
+| `get-layer-details`         | Inspect a layer (effects, blend, parent, 3D) |
+
+> ℹ️ Output format for `render-video` is determined by the chosen output module template (or the default one); on some installs the default is H.264 (.mp4). `save-frame` is handy for letting an AI assistant inspect the rendered result.
 
 ## 👨‍💻 For Developers
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -190,7 +190,25 @@ server.tool(
       "setCompositionProperties",
       "duplicateLayer",
       "deleteLayer",
-      "setLayerMask"
+      "setLayerMask",
+      "saveFrame",
+      "moveLayer",
+      "importFootage",
+      "precompose",
+      "setLayerParent",
+      "createNull",
+      "setBlendMode",
+      "setTrackMatte",
+      "removeEffect",
+      "reorderEffect",
+      "createLight",
+      "set3DLayer",
+      "renderComposition",
+      "setKeyframeEase",
+      "applyTrimPaths",
+      "addTextAnimator",
+      "saveProject",
+      "getLayerDetails"
     ];
     
     if (!allowedScripts.includes(script)) {
@@ -431,7 +449,685 @@ server.tool(
   }
 );
 
-// --- BEGIN NEW TOOLS --- 
+// Add a tool for saving a single composition frame to a PNG file
+server.tool(
+  "save-frame",
+  "Render a single frame of a composition to a PNG file at the given time, so the image can be inspected.",
+  {
+    compName: z.string().optional().describe("Name of the composition. Defaults to the active composition if omitted."),
+    time: z.number().min(0).optional().describe("Time in seconds of the frame to capture (default: 0)."),
+    outPath: z.string().describe("Absolute path of the PNG file to write (parent folders are created if needed).")
+  },
+  async (params) => {
+    try {
+      writeCommandFile("saveFrame", params);
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Command to save frame at ${params.time ?? 0}s to "${params.outPath}" has been queued.\n` +
+                  `Please ensure the "MCP Bridge Auto" panel is open in After Effects.\n` +
+                  `Use the "get-results" tool after a few seconds to check for results.`
+          }
+        ]
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Error queuing save-frame: ${String(error)}`
+          }
+        ],
+        isError: true
+      };
+    }
+  }
+);
+
+// Add a tool for reordering a layer within its composition
+server.tool(
+  "move-layer",
+  "Reorder a layer within a composition (bring to front/back, or move before/after another layer, or to a specific index).",
+  {
+    compName: z.string().optional().describe("Name of the composition. Defaults to the active composition if omitted."),
+    layerIndex: z.number().int().positive().optional().describe("1-based index of the layer to move (use this or layerName)."),
+    layerName: z.string().optional().describe("Name of the layer to move (use this or layerIndex)."),
+    position: z.enum(["front", "back", "before", "after"]).optional().describe("Where to move the layer. 'front' = topmost, 'back' = bottommost. For 'before'/'after', also provide a reference layer."),
+    toIndex: z.number().int().positive().optional().describe("Alternative to 'position': move the layer to this 1-based index."),
+    referenceLayerIndex: z.number().int().positive().optional().describe("Reference layer index for 'before'/'after'."),
+    referenceLayerName: z.string().optional().describe("Reference layer name for 'before'/'after'.")
+  },
+  async (params) => {
+    try {
+      writeCommandFile("moveLayer", params);
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Command to move layer has been queued.\n` +
+                  `Please ensure the "MCP Bridge Auto" panel is open in After Effects.\n` +
+                  `Use the "get-results" tool after a few seconds to check for results.`
+          }
+        ]
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Error queuing move-layer: ${String(error)}`
+          }
+        ],
+        isError: true
+      };
+    }
+  }
+);
+
+// Tool: import footage into the project
+server.tool(
+  "import-footage",
+  "Import a footage file into the project, optionally adding it to a composition.",
+  {
+    filePath: z.string().describe("Absolute path of the file to import."),
+    importAs: z.enum(["footage", "comp"]).optional().describe("How to import the file."),
+    addToComp: z.boolean().optional().describe("Whether to add the imported item to a composition."),
+    compName: z.string().optional().describe("Name of the composition. Defaults to the active composition if omitted."),
+    position: z.array(z.number()).optional().describe("Position [x, y] of the layer if added to a comp."),
+    startTime: z.number().optional().describe("Start time in seconds of the layer if added to a comp.")
+  },
+  async (params) => {
+    try {
+      writeCommandFile("importFootage", params);
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Command 'import-footage' has been queued. Use the "get-results" tool after a few seconds to check results.`
+          }
+        ]
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Error queuing import-footage: ${String(error)}`
+          }
+        ],
+        isError: true
+      };
+    }
+  }
+);
+
+// Tool: precompose layers
+server.tool(
+  "precompose",
+  "Precompose one or more layers in a composition into a new nested composition.",
+  {
+    compName: z.string().optional().describe("Name of the composition. Defaults to the active composition if omitted."),
+    layerIndices: z.array(z.number().int().positive()).describe("1-based indices of the layers to precompose."),
+    name: z.string().optional().describe("Name of the new precomposition."),
+    moveAllAttributes: z.boolean().optional().describe("Whether to move all attributes into the new composition.")
+  },
+  async (params) => {
+    try {
+      writeCommandFile("precompose", params);
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Command 'precompose' has been queued. Use the "get-results" tool after a few seconds to check results.`
+          }
+        ]
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Error queuing precompose: ${String(error)}`
+          }
+        ],
+        isError: true
+      };
+    }
+  }
+);
+
+// Tool: set a layer's parent
+server.tool(
+  "set-parent",
+  "Set or remove the parent of a layer in a composition.",
+  {
+    compName: z.string().optional().describe("Name of the composition. Defaults to the active composition if omitted."),
+    layerIndex: z.number().int().positive().optional().describe("1-based index of the child layer (use this or layerName)."),
+    layerName: z.string().optional().describe("Name of the child layer (use this or layerIndex)."),
+    parentIndex: z.number().int().positive().optional().describe("1-based index of the parent layer (use this or parentName)."),
+    parentName: z.string().optional().describe("Name of the parent layer (use this or parentIndex)."),
+    unparent: z.boolean().optional().describe("If true, removes the layer's parent.")
+  },
+  async (params) => {
+    try {
+      writeCommandFile("setLayerParent", params);
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Command 'set-parent' has been queued. Use the "get-results" tool after a few seconds to check results.`
+          }
+        ]
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Error queuing set-parent: ${String(error)}`
+          }
+        ],
+        isError: true
+      };
+    }
+  }
+);
+
+// Tool: create a null layer
+server.tool(
+  "create-null",
+  "Create a null object layer in a composition.",
+  {
+    compName: z.string().optional().describe("Name of the composition. Defaults to the active composition if omitted."),
+    name: z.string().optional().describe("Name of the new null layer."),
+    position: z.array(z.number()).optional().describe("Position [x, y] of the null layer."),
+    duration: z.number().positive().optional().describe("Duration in seconds of the null layer.")
+  },
+  async (params) => {
+    try {
+      writeCommandFile("createNull", params);
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Command 'create-null' has been queued. Use the "get-results" tool after a few seconds to check results.`
+          }
+        ]
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Error queuing create-null: ${String(error)}`
+          }
+        ],
+        isError: true
+      };
+    }
+  }
+);
+
+// Tool: set a layer's blend mode
+server.tool(
+  "set-blend-mode",
+  "Set the blending mode of a layer in a composition.",
+  {
+    compName: z.string().optional().describe("Name of the composition. Defaults to the active composition if omitted."),
+    layerIndex: z.number().int().positive().optional().describe("1-based index of the layer (use this or layerName)."),
+    layerName: z.string().optional().describe("Name of the layer (use this or layerIndex)."),
+    mode: z.enum(["normal", "add", "screen", "multiply", "overlay", "lighten", "darken", "softLight", "hardLight", "difference", "colorDodge", "colorBurn", "linearDodge", "linearBurn", "hue", "saturation", "color", "luminosity"]).describe("The blending mode to apply.")
+  },
+  async (params) => {
+    try {
+      writeCommandFile("setBlendMode", params);
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Command 'set-blend-mode' has been queued. Use the "get-results" tool after a few seconds to check results.`
+          }
+        ]
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Error queuing set-blend-mode: ${String(error)}`
+          }
+        ],
+        isError: true
+      };
+    }
+  }
+);
+
+// Tool: set a layer's track matte
+server.tool(
+  "set-track-matte",
+  "Set or remove the track matte of a layer in a composition.",
+  {
+    compName: z.string().optional().describe("Name of the composition. Defaults to the active composition if omitted."),
+    layerIndex: z.number().int().positive().optional().describe("1-based index of the layer (use this or layerName)."),
+    layerName: z.string().optional().describe("Name of the layer (use this or layerIndex)."),
+    matteType: z.enum(["none", "alpha", "alphaInverted", "luma", "lumaInverted"]).describe("The track matte type to apply."),
+    matteLayerIndex: z.number().int().positive().optional().describe("1-based index of the matte layer (use this or matteLayerName)."),
+    matteLayerName: z.string().optional().describe("Name of the matte layer (use this or matteLayerIndex).")
+  },
+  async (params) => {
+    try {
+      writeCommandFile("setTrackMatte", params);
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Command 'set-track-matte' has been queued. Use the "get-results" tool after a few seconds to check results.`
+          }
+        ]
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Error queuing set-track-matte: ${String(error)}`
+          }
+        ],
+        isError: true
+      };
+    }
+  }
+);
+
+// Tool: remove an effect from a layer
+server.tool(
+  "remove-effect",
+  "Remove an effect from a layer in a composition.",
+  {
+    compName: z.string().optional().describe("Name of the composition. Defaults to the active composition if omitted."),
+    layerIndex: z.number().int().positive().optional().describe("1-based index of the layer (use this or layerName)."),
+    layerName: z.string().optional().describe("Name of the layer (use this or layerIndex)."),
+    effectIndex: z.number().int().positive().optional().describe("1-based index of the effect to remove (use this or effectName)."),
+    effectName: z.string().optional().describe("Name of the effect to remove (use this or effectIndex).")
+  },
+  async (params) => {
+    try {
+      writeCommandFile("removeEffect", params);
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Command 'remove-effect' has been queued. Use the "get-results" tool after a few seconds to check results.`
+          }
+        ]
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Error queuing remove-effect: ${String(error)}`
+          }
+        ],
+        isError: true
+      };
+    }
+  }
+);
+
+// Tool: reorder an effect on a layer
+server.tool(
+  "reorder-effect",
+  "Reorder an effect within a layer's effect stack in a composition.",
+  {
+    compName: z.string().optional().describe("Name of the composition. Defaults to the active composition if omitted."),
+    layerIndex: z.number().int().positive().optional().describe("1-based index of the layer (use this or layerName)."),
+    layerName: z.string().optional().describe("Name of the layer (use this or layerIndex)."),
+    effectIndex: z.number().int().positive().describe("1-based index of the effect to move."),
+    toIndex: z.number().int().positive().describe("1-based target index to move the effect to.")
+  },
+  async (params) => {
+    try {
+      writeCommandFile("reorderEffect", params);
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Command 'reorder-effect' has been queued. Use the "get-results" tool after a few seconds to check results.`
+          }
+        ]
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Error queuing reorder-effect: ${String(error)}`
+          }
+        ],
+        isError: true
+      };
+    }
+  }
+);
+
+// Tool: create a light layer
+server.tool(
+  "create-light",
+  "Create a light layer in a composition.",
+  {
+    compName: z.string().optional().describe("Name of the composition. Defaults to the active composition if omitted."),
+    name: z.string().optional().describe("Name of the new light layer."),
+    lightType: z.enum(["parallel", "spot", "point", "ambient"]).optional().describe("The type of light to create."),
+    position: z.array(z.number()).optional().describe("Position [x, y, z] of the light."),
+    pointOfInterest: z.array(z.number()).optional().describe("Point of interest [x, y, z] of the light."),
+    intensity: z.number().optional().describe("Intensity of the light."),
+    color: z.array(z.number()).optional().describe("Color [r, g, b] of the light (0-1).")
+  },
+  async (params) => {
+    try {
+      writeCommandFile("createLight", params);
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Command 'create-light' has been queued. Use the "get-results" tool after a few seconds to check results.`
+          }
+        ]
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Error queuing create-light: ${String(error)}`
+          }
+        ],
+        isError: true
+      };
+    }
+  }
+);
+
+// Tool: toggle 3D on a layer
+server.tool(
+  "set-3d-layer",
+  "Enable or disable the 3D property of a layer in a composition.",
+  {
+    compName: z.string().optional().describe("Name of the composition. Defaults to the active composition if omitted."),
+    layerIndex: z.number().int().positive().optional().describe("1-based index of the layer (use this or layerName)."),
+    layerName: z.string().optional().describe("Name of the layer (use this or layerIndex)."),
+    enabled: z.boolean().optional().describe("Whether to enable (true) or disable (false) the 3D property.")
+  },
+  async (params) => {
+    try {
+      writeCommandFile("set3DLayer", params);
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Command 'set-3d-layer' has been queued. Use the "get-results" tool after a few seconds to check results.`
+          }
+        ]
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Error queuing set-3d-layer: ${String(error)}`
+          }
+        ],
+        isError: true
+      };
+    }
+  }
+);
+
+// Tool: render a composition to video
+server.tool(
+  "render-video",
+  "Render a composition to a video file via the render queue.",
+  {
+    compName: z.string().optional().describe("Name of the composition. Defaults to the active composition if omitted."),
+    outPath: z.string().describe("Absolute path of the output file to write."),
+    outputModuleTemplate: z.string().optional().describe("Name of the output module template to use."),
+    startTime: z.number().optional().describe("Start time in seconds of the render range."),
+    duration: z.number().optional().describe("Duration in seconds of the render range.")
+  },
+  async (params) => {
+    try {
+      writeCommandFile("renderComposition", params);
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Command 'render-video' has been queued. Use the "get-results" tool after a few seconds to check results.`
+          }
+        ]
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Error queuing render-video: ${String(error)}`
+          }
+        ],
+        isError: true
+      };
+    }
+  }
+);
+
+// Tool: set keyframe ease
+server.tool(
+  "set-keyframe-ease",
+  "Set the temporal ease (easing) on keyframes of a layer property in a composition.",
+  {
+    compName: z.string().optional().describe("Name of the composition. Defaults to the active composition if omitted."),
+    layerIndex: z.number().int().positive().optional().describe("1-based index of the layer (use this or layerName)."),
+    layerName: z.string().optional().describe("Name of the layer (use this or layerIndex)."),
+    propertyName: z.string().describe("Name of the property whose keyframes to ease."),
+    easeType: z.enum(["easyEase", "easeIn", "easeOut", "linear"]).optional().describe("The type of ease to apply."),
+    influence: z.number().optional().describe("Ease influence percentage."),
+    keyIndex: z.number().int().positive().optional().describe("1-based index of a specific keyframe to ease (omit to apply to all).")
+  },
+  async (params) => {
+    try {
+      writeCommandFile("setKeyframeEase", params);
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Command 'set-keyframe-ease' has been queued. Use the "get-results" tool after a few seconds to check results.`
+          }
+        ]
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Error queuing set-keyframe-ease: ${String(error)}`
+          }
+        ],
+        isError: true
+      };
+    }
+  }
+);
+
+// Tool: apply trim paths to a shape layer
+server.tool(
+  "apply-trim-paths",
+  "Apply Trim Paths to a shape layer in a composition, optionally with a draw-on animation.",
+  {
+    compName: z.string().optional().describe("Name of the composition. Defaults to the active composition if omitted."),
+    layerIndex: z.number().int().positive().optional().describe("1-based index of the layer (use this or layerName)."),
+    layerName: z.string().optional().describe("Name of the layer (use this or layerIndex)."),
+    start: z.number().optional().describe("Trim Paths start percentage."),
+    end: z.number().optional().describe("Trim Paths end percentage."),
+    offset: z.number().optional().describe("Trim Paths offset in degrees."),
+    drawOn: z.object({
+      from: z.number().optional(),
+      to: z.number().optional(),
+      startTime: z.number().optional(),
+      duration: z.number().optional()
+    }).optional().describe("Optional draw-on animation settings.")
+  },
+  async (params) => {
+    try {
+      writeCommandFile("applyTrimPaths", params);
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Command 'apply-trim-paths' has been queued. Use the "get-results" tool after a few seconds to check results.`
+          }
+        ]
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Error queuing apply-trim-paths: ${String(error)}`
+          }
+        ],
+        isError: true
+      };
+    }
+  }
+);
+
+// Tool: add a text animator to a text layer
+server.tool(
+  "add-text-animator",
+  "Add a text animator to a text layer in a composition.",
+  {
+    compName: z.string().optional().describe("Name of the composition. Defaults to the active composition if omitted."),
+    layerIndex: z.number().int().positive().optional().describe("1-based index of the layer (use this or layerName)."),
+    layerName: z.string().optional().describe("Name of the layer (use this or layerIndex)."),
+    property: z.enum(["opacity", "position", "scale", "rotation"]).optional().describe("The property the animator controls."),
+    value: z.any().optional().describe("The animator property value."),
+    offset: z.number().optional().describe("Range selector offset."),
+    revealDuration: z.number().optional().describe("Duration of the reveal animation in seconds."),
+    startTime: z.number().optional().describe("Start time in seconds of the animation."),
+    name: z.string().optional().describe("Name of the animator.")
+  },
+  async (params) => {
+    try {
+      writeCommandFile("addTextAnimator", params);
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Command 'add-text-animator' has been queued. Use the "get-results" tool after a few seconds to check results.`
+          }
+        ]
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Error queuing add-text-animator: ${String(error)}`
+          }
+        ],
+        isError: true
+      };
+    }
+  }
+);
+
+// Tool: save the project
+server.tool(
+  "save-project",
+  "Save the current After Effects project, optionally to a new path.",
+  {
+    path: z.string().optional().describe("Absolute path to save the project to. Saves in place if omitted.")
+  },
+  async (params) => {
+    try {
+      writeCommandFile("saveProject", params);
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Command 'save-project' has been queued. Use the "get-results" tool after a few seconds to check results.`
+          }
+        ]
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Error queuing save-project: ${String(error)}`
+          }
+        ],
+        isError: true
+      };
+    }
+  }
+);
+
+// Tool: get detailed information about a layer
+server.tool(
+  "get-layer-details",
+  "Get detailed information about a layer in a composition.",
+  {
+    compName: z.string().optional().describe("Name of the composition. Defaults to the active composition if omitted."),
+    layerIndex: z.number().int().positive().optional().describe("1-based index of the layer (use this or layerName)."),
+    layerName: z.string().optional().describe("Name of the layer (use this or layerIndex).")
+  },
+  async (params) => {
+    try {
+      writeCommandFile("getLayerDetails", params);
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Command 'get-layer-details' has been queued. Use the "get-results" tool after a few seconds to check results.`
+          }
+        ]
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Error queuing get-layer-details: ${String(error)}`
+          }
+        ],
+        isError: true
+      };
+    }
+  }
+);
+
+// --- BEGIN NEW TOOLS ---
 
 // Zod schema for common layer identification
 const LayerIdentifierSchema = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -208,7 +208,8 @@ server.tool(
       "applyTrimPaths",
       "addTextAnimator",
       "saveProject",
-      "getLayerDetails"
+      "getLayerDetails",
+      "deleteComposition"
     ];
     
     if (!allowedScripts.includes(script)) {
@@ -1119,6 +1120,39 @@ server.tool(
           {
             type: "text",
             text: `Error queuing get-layer-details: ${String(error)}`
+          }
+        ],
+        isError: true
+      };
+    }
+  }
+);
+
+// Add a tool for deleting a composition from the project
+server.tool(
+  "delete-composition",
+  "Delete a composition from the project (by name or 1-based project item index).",
+  {
+    compName: z.string().optional().describe("Name of the composition to delete (use this or compIndex)."),
+    compIndex: z.number().int().positive().optional().describe("1-based project item index of the composition (use this or compName).")
+  },
+  async (params) => {
+    try {
+      writeCommandFile("deleteComposition", params);
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Command 'delete-composition' has been queued. Use the "get-results" tool after a few seconds to check results.`
+          }
+        ]
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Error queuing delete-composition: ${String(error)}`
           }
         ],
         isError: true

--- a/src/scripts/mcp-bridge-auto.jsx
+++ b/src/scripts/mcp-bridge-auto.jsx
@@ -970,13 +970,16 @@ function addTextAnimator(args) {
 
         var selectors = animator.property("ADBE Text Selectors");
         var sel = selectors.addProperty("ADBE Text Selector");
-        var offsetProp = sel.property("ADBE Text Percent Offset");
         if (args.revealDuration) {
+            // Reveal left-to-right: animate the Range Selector Start from 0% to 100%.
+            // With the animator's Opacity = 0 (selected chars hidden), this makes the
+            // hidden selection retreat left-to-right, ending with ALL characters visible.
             var st = (args.startTime !== undefined) ? args.startTime : 0;
-            offsetProp.setValueAtTime(st, -100);
-            offsetProp.setValueAtTime(st + args.revealDuration, 0);
+            var startProp = sel.property("ADBE Text Percent Start");
+            startProp.setValueAtTime(st, 0);
+            startProp.setValueAtTime(st + args.revealDuration, 100);
         } else if (args.offset !== undefined && args.offset !== null) {
-            offsetProp.setValue(args.offset);
+            sel.property("ADBE Text Percent Offset").setValue(args.offset);
         }
         return JSON.stringify({ status: "success", message: "Text animator added", layer: layer.name, animator: animator.name }, null, 2);
     } catch (error) {

--- a/src/scripts/mcp-bridge-auto.jsx
+++ b/src/scripts/mcp-bridge-auto.jsx
@@ -474,7 +474,10 @@ function saveFrame(args) {
 
         // saveFrameToPng renders the comp at the given time (seconds) to a PNG file
         comp.saveFrameToPng(time, outFile);
-        if (!outFile.exists) {
+        // Re-stat with a FRESH File object: ExtendScript caches File.exists on the
+        // original object, which was created before the file existed.
+        var writtenFile = new File(outFile.fsName);
+        if (!writtenFile.exists) {
             throw new Error("saveFrameToPng reported no error but the output file was not created: " + outFile.fsName);
         }
 
@@ -853,10 +856,11 @@ function renderComposition(args) {
         }
         om.file = new File(args.outPath);
         app.project.renderQueue.render(); // blocking: freezes AE until the render finishes
-        var savedFile = om.file;
-        var savedPath = savedFile.fsName;
+        var savedPath = om.file.fsName;
         try { rqItem.remove(); } catch (er) {}
-        if (!savedFile.exists) {
+        // Re-stat with a fresh File object (ExtendScript caches File.exists).
+        var verifyFile = new File(savedPath);
+        if (!verifyFile.exists) {
             throw new Error("Render reported complete but the output file was not created: " + savedPath);
         }
         var renderResult = { status: "success", message: "Render complete", path: savedPath, comp: comp.name };

--- a/src/scripts/mcp-bridge-auto.jsx
+++ b/src/scripts/mcp-bridge-auto.jsx
@@ -1031,6 +1031,30 @@ function getLayerDetails(args) {
     }
 }
 
+// --- deleteComposition: remove a composition from the project ---
+function deleteComposition(args) {
+    try {
+        var compName = args.compName || "";
+        var compIndex = args.compIndex;
+        var target = null;
+        if (compName) {
+            for (var i = 1; i <= app.project.numItems; i++) {
+                var it = app.project.item(i);
+                if (it instanceof CompItem && it.name === compName) { target = it; break; }
+            }
+        } else if (compIndex !== undefined && compIndex !== null) {
+            var it2 = app.project.item(compIndex);
+            if (it2 && it2 instanceof CompItem) { target = it2; }
+        }
+        if (!target) { throw new Error("Composition not found"); }
+        var nm = target.name;
+        target.remove();
+        return JSON.stringify({ status: "success", message: "Composition deleted", name: nm }, null, 2);
+    } catch (error) {
+        return JSON.stringify({ status: "error", message: error.toString() }, null, 2);
+    }
+}
+
 // --- setLayerProperties (modified to handle text properties) ---
 function setLayerProperties(args) {
     try {
@@ -2185,6 +2209,11 @@ function executeCommand(command, args) {
                 logToPanel("Calling moveLayer function...");
                 result = moveLayer(args);
                 logToPanel("Returned from moveLayer.");
+                break;
+            case "deleteComposition":
+                logToPanel("Calling deleteComposition function...");
+                result = deleteComposition(args);
+                logToPanel("Returned from deleteComposition.");
                 break;
             case "importFootage":
                 logToPanel("Calling importFootage function...");

--- a/src/scripts/mcp-bridge-auto.jsx
+++ b/src/scripts/mcp-bridge-auto.jsx
@@ -450,6 +450,587 @@ function createSolidLayer(args) {
     }
 }
 
+// --- saveFrame: render a single composition frame to a PNG file ---
+function saveFrame(args) {
+    try {
+        var compName = args.compName || "";
+        var time = (args.time !== undefined && args.time !== null) ? args.time : 0;
+        var outPath = args.outPath;
+        if (!outPath) { throw new Error("outPath is required"); }
+
+        var comp = null;
+        for (var i = 1; i <= app.project.numItems; i++) {
+            var item = app.project.item(i);
+            if (item instanceof CompItem && item.name === compName) { comp = item; break; }
+        }
+        if (!comp) {
+            if (app.project.activeItem instanceof CompItem) { comp = app.project.activeItem; }
+            else { throw new Error("No composition found with name '" + compName + "' and no active composition"); }
+        }
+
+        var outFile = new File(outPath);
+        var parent = outFile.parent;
+        if (parent && !parent.exists) { parent.create(); }
+
+        // saveFrameToPng renders the comp at the given time (seconds) to a PNG file
+        comp.saveFrameToPng(time, outFile);
+        if (!outFile.exists) {
+            throw new Error("saveFrameToPng reported no error but the output file was not created: " + outFile.fsName);
+        }
+
+        return JSON.stringify({
+            status: "success",
+            message: "Frame saved successfully",
+            path: outFile.fsName,
+            comp: comp.name,
+            time: time
+        }, null, 2);
+    } catch (error) {
+        return JSON.stringify({ status: "error", message: error.toString() }, null, 2);
+    }
+}
+
+// --- moveLayer: reorder a layer within its composition ---
+function moveLayer(args) {
+    try {
+        var compName = args.compName || "";
+        var layerIndex = args.layerIndex;
+        var layerName = args.layerName || "";
+        var position = args.position; // "front" | "back" | "before" | "after"
+        var toIndex = args.toIndex;   // optional 1-based target index
+        var referenceLayerIndex = args.referenceLayerIndex;
+        var referenceLayerName = args.referenceLayerName || "";
+
+        var comp = null;
+        for (var i = 1; i <= app.project.numItems; i++) {
+            var item = app.project.item(i);
+            if (item instanceof CompItem && item.name === compName) { comp = item; break; }
+        }
+        if (!comp) {
+            if (app.project.activeItem instanceof CompItem) { comp = app.project.activeItem; }
+            else { throw new Error("No composition found with name '" + compName + "' and no active composition"); }
+        }
+
+        // Resolve the layer to move
+        var layer = null;
+        if (layerIndex !== undefined && layerIndex !== null) {
+            if (layerIndex > 0 && layerIndex <= comp.numLayers) { layer = comp.layer(layerIndex); }
+            else { throw new Error("Layer index out of bounds: " + layerIndex); }
+        } else if (layerName) {
+            for (var j = 1; j <= comp.numLayers; j++) {
+                if (comp.layer(j).name === layerName) { layer = comp.layer(j); break; }
+            }
+        }
+        if (!layer) { throw new Error("Layer not found: " + (layerName || "index " + layerIndex)); }
+
+        if (toIndex !== undefined && toIndex !== null) {
+            toIndex = Math.max(1, Math.min(comp.numLayers, toIndex));
+            if (toIndex < layer.index) { layer.moveBefore(comp.layer(toIndex)); }
+            else if (toIndex > layer.index) { layer.moveAfter(comp.layer(toIndex)); }
+            // equal => no change
+        } else if (position === "front") {
+            layer.moveToBeginning();
+        } else if (position === "back") {
+            layer.moveToEnd();
+        } else if (position === "before" || position === "after") {
+            var ref = null;
+            if (referenceLayerIndex !== undefined && referenceLayerIndex !== null) {
+                if (referenceLayerIndex > 0 && referenceLayerIndex <= comp.numLayers) { ref = comp.layer(referenceLayerIndex); }
+            } else if (referenceLayerName) {
+                for (var k = 1; k <= comp.numLayers; k++) {
+                    if (comp.layer(k).name === referenceLayerName) { ref = comp.layer(k); break; }
+                }
+            }
+            if (!ref) { throw new Error("Reference layer not found for '" + position + "'"); }
+            if (position === "before") { layer.moveBefore(ref); } else { layer.moveAfter(ref); }
+        } else {
+            throw new Error("Specify either 'toIndex' or 'position' ('front'|'back'|'before'|'after')");
+        }
+
+        return JSON.stringify({
+            status: "success",
+            message: "Layer moved successfully",
+            layer: { name: layer.name, newIndex: layer.index }
+        }, null, 2);
+    } catch (error) {
+        return JSON.stringify({ status: "error", message: error.toString() }, null, 2);
+    }
+}
+
+// =====================================================================
+// ===== Extended general-purpose commands (added 2026-06-04) ==========
+// =====================================================================
+
+// Shared helpers for the extended commands.
+// If a (non-empty) compName is supplied, it MUST match by name — we do NOT
+// silently fall back to the active comp, to avoid acting on the wrong comp.
+// Only when compName is omitted/empty do we use the active composition.
+function mcpFindComp(compName) {
+    if (compName) {
+        for (var i = 1; i <= app.project.numItems; i++) {
+            var it = app.project.item(i);
+            if (it instanceof CompItem && it.name === compName) { return it; }
+        }
+        return null; // named comp requested but not found — caller will throw
+    }
+    if (app.project.activeItem instanceof CompItem) { return app.project.activeItem; }
+    return null;
+}
+
+function mcpFindLayer(comp, layerIndex, layerName) {
+    if (layerIndex !== undefined && layerIndex !== null) {
+        if (layerIndex > 0 && layerIndex <= comp.numLayers) { return comp.layer(layerIndex); }
+        return null;
+    }
+    if (layerName) {
+        for (var j = 1; j <= comp.numLayers; j++) {
+            if (comp.layer(j).name === layerName) { return comp.layer(j); }
+        }
+    }
+    return null;
+}
+
+// --- importFootage: import a file into the project, optionally add to a comp ---
+function importFootage(args) {
+    try {
+        var filePath = args.filePath;
+        if (!filePath) { throw new Error("filePath is required"); }
+        var f = new File(filePath);
+        if (!f.exists) { throw new Error("File not found: " + filePath); }
+
+        var io = new ImportOptions(f);
+        if (args.importAs === "comp" && io.canImportAs(ImportAsType.COMP)) { io.importAs = ImportAsType.COMP; }
+        var item = app.project.importFile(io);
+
+        var result = { status: "success", message: "Footage imported", name: item.name, id: item.id, typeName: item.typeName };
+        if (args.addToComp) {
+            var comp = mcpFindComp(args.compName || "");
+            if (!comp) { throw new Error("addToComp requested but composition not found"); }
+            var layer = comp.layers.add(item);
+            if (args.position) { layer.property("Position").setValue(args.position); }
+            if (args.startTime !== undefined && args.startTime !== null) { layer.startTime = args.startTime; }
+            result.layerIndex = layer.index;
+            result.layerName = layer.name;
+        }
+        return JSON.stringify(result, null, 2);
+    } catch (error) {
+        return JSON.stringify({ status: "error", message: error.toString() }, null, 2);
+    }
+}
+
+// --- precompose: nest the given layers into a new composition ---
+function precompose(args) {
+    try {
+        var comp = mcpFindComp(args.compName || "");
+        if (!comp) { throw new Error("Composition not found"); }
+        var indices = args.layerIndices;
+        if (!indices || !indices.length) { throw new Error("layerIndices (array of 1-based indices) is required"); }
+        var name = args.name || "Precomp";
+        var moveAll = (args.moveAllAttributes !== undefined) ? args.moveAllAttributes : true;
+        // AE only allows moveAllAttributes=false when precomposing a SINGLE layer.
+        if (!moveAll && indices.length > 1) {
+            throw new Error("moveAllAttributes=false is only allowed when precomposing a single layer");
+        }
+        var newComp = comp.layers.precompose(indices, name, moveAll);
+        return JSON.stringify({ status: "success", message: "Precomposed", comp: newComp.name, id: newComp.id }, null, 2);
+    } catch (error) {
+        return JSON.stringify({ status: "error", message: error.toString() }, null, 2);
+    }
+}
+
+// --- setLayerParent: set or clear a layer's parent ---
+function setLayerParent(args) {
+    try {
+        var comp = mcpFindComp(args.compName || "");
+        if (!comp) { throw new Error("Composition not found"); }
+        var layer = mcpFindLayer(comp, args.layerIndex, args.layerName);
+        if (!layer) { throw new Error("Layer not found"); }
+        if (args.unparent) {
+            layer.parent = null;
+        } else {
+            var p = mcpFindLayer(comp, args.parentIndex, args.parentName);
+            if (!p) { throw new Error("Parent layer not found"); }
+            layer.parent = p;
+        }
+        return JSON.stringify({ status: "success", message: "Parent updated", layer: layer.name, parent: layer.parent ? layer.parent.name : null }, null, 2);
+    } catch (error) {
+        return JSON.stringify({ status: "error", message: error.toString() }, null, 2);
+    }
+}
+
+// --- createNull: add a null object layer ---
+function createNull(args) {
+    try {
+        var comp = mcpFindComp(args.compName || "");
+        if (!comp) { throw new Error("Composition not found"); }
+        var dur = (args.duration !== undefined && args.duration !== null) ? args.duration : comp.duration;
+        var nullLayer = comp.layers.addNull(dur);
+        if (args.name) { nullLayer.name = args.name; }
+        if (args.position) { nullLayer.property("Position").setValue(args.position); }
+        return JSON.stringify({ status: "success", message: "Null created", name: nullLayer.name, index: nullLayer.index }, null, 2);
+    } catch (error) {
+        return JSON.stringify({ status: "error", message: error.toString() }, null, 2);
+    }
+}
+
+// --- setBlendMode: set a layer's blending mode ---
+function setBlendMode(args) {
+    try {
+        var comp = mcpFindComp(args.compName || "");
+        if (!comp) { throw new Error("Composition not found"); }
+        var layer = mcpFindLayer(comp, args.layerIndex, args.layerName);
+        if (!layer) { throw new Error("Layer not found"); }
+        var modes = {
+            "normal": BlendingMode.NORMAL, "add": BlendingMode.ADD, "screen": BlendingMode.SCREEN,
+            "multiply": BlendingMode.MULTIPLY, "overlay": BlendingMode.OVERLAY, "lighten": BlendingMode.LIGHTEN,
+            "darken": BlendingMode.DARKEN, "softLight": BlendingMode.SOFT_LIGHT, "hardLight": BlendingMode.HARD_LIGHT,
+            "difference": BlendingMode.DIFFERENCE, "colorDodge": BlendingMode.CLASSIC_COLOR_DODGE,
+            "colorBurn": BlendingMode.CLASSIC_COLOR_BURN, "linearDodge": BlendingMode.LINEAR_DODGE,
+            "linearBurn": BlendingMode.LINEAR_BURN, "hue": BlendingMode.HUE, "saturation": BlendingMode.SATURATION,
+            "color": BlendingMode.COLOR, "luminosity": BlendingMode.LUMINOSITY
+        };
+        var m = modes[args.mode];
+        if (m === undefined) { throw new Error("Unknown blend mode: " + args.mode); }
+        layer.blendingMode = m;
+        return JSON.stringify({ status: "success", message: "Blend mode set", layer: layer.name, mode: args.mode }, null, 2);
+    } catch (error) {
+        return JSON.stringify({ status: "error", message: error.toString() }, null, 2);
+    }
+}
+
+// --- setTrackMatte: set a track matte for a layer ---
+function setTrackMatte(args) {
+    try {
+        var comp = mcpFindComp(args.compName || "");
+        if (!comp) { throw new Error("Composition not found"); }
+        var layer = mcpFindLayer(comp, args.layerIndex, args.layerName);
+        if (!layer) { throw new Error("Layer not found"); }
+        var types = {
+            "none": TrackMatteType.NO_TRACK_MATTE, "alpha": TrackMatteType.ALPHA,
+            "alphaInverted": TrackMatteType.ALPHA_INVERTED, "luma": TrackMatteType.LUMA,
+            "lumaInverted": TrackMatteType.LUMA_INVERTED
+        };
+        var t = types[args.matteType];
+        if (t === undefined) { throw new Error("Unknown matteType: " + args.matteType); }
+        // If the caller explicitly named a matte layer, it MUST resolve — do not
+        // silently fall back to the "layer directly above" legacy behavior.
+        var matteRequested = (args.matteLayerIndex !== undefined && args.matteLayerIndex !== null) ||
+                             (args.matteLayerName !== undefined && args.matteLayerName !== null && args.matteLayerName !== "");
+        var matteLayer = mcpFindLayer(comp, args.matteLayerIndex, args.matteLayerName);
+        if (matteRequested && !matteLayer) {
+            throw new Error("Requested matte layer not found");
+        }
+        var usedLegacyApi = false;
+        if (matteLayer && layer.setTrackMatte) {
+            layer.setTrackMatte(matteLayer, t); // AE 23.0+ explicit matte-layer link
+        } else {
+            // Legacy model: matte is the layer directly above `layer`.
+            layer.trackMatteType = t;
+            usedLegacyApi = true;
+        }
+        return JSON.stringify({ status: "success", message: "Track matte set", layer: layer.name, matteType: args.matteType, usedLegacyApi: usedLegacyApi }, null, 2);
+    } catch (error) {
+        return JSON.stringify({ status: "error", message: error.toString() }, null, 2);
+    }
+}
+
+// --- removeEffect: remove an effect from a layer ---
+function removeEffect(args) {
+    try {
+        var comp = mcpFindComp(args.compName || "");
+        if (!comp) { throw new Error("Composition not found"); }
+        var layer = mcpFindLayer(comp, args.layerIndex, args.layerName);
+        if (!layer) { throw new Error("Layer not found"); }
+        var fx = layer.property("ADBE Effect Parade");
+        if (!fx || fx.numProperties === 0) { throw new Error("Layer has no effects"); }
+        var target = null;
+        if (args.effectIndex !== undefined && args.effectIndex !== null) {
+            target = fx.property(args.effectIndex);
+        } else if (args.effectName) {
+            for (var i = 1; i <= fx.numProperties; i++) {
+                if (fx.property(i).name === args.effectName) { target = fx.property(i); break; }
+            }
+        }
+        if (!target) { throw new Error("Effect not found"); }
+        var nm = target.name;
+        target.remove();
+        return JSON.stringify({ status: "success", message: "Effect removed", removed: nm }, null, 2);
+    } catch (error) {
+        return JSON.stringify({ status: "error", message: error.toString() }, null, 2);
+    }
+}
+
+// --- reorderEffect: move an effect to a new position in the effect stack ---
+function reorderEffect(args) {
+    try {
+        var comp = mcpFindComp(args.compName || "");
+        if (!comp) { throw new Error("Composition not found"); }
+        var layer = mcpFindLayer(comp, args.layerIndex, args.layerName);
+        if (!layer) { throw new Error("Layer not found"); }
+        var fx = layer.property("ADBE Effect Parade");
+        if (!fx || fx.numProperties === 0) { throw new Error("Layer has no effects"); }
+        var e = fx.property(args.effectIndex);
+        if (!e) { throw new Error("Effect not found at index " + args.effectIndex); }
+        var effectName = e.name;
+        var to = Math.max(1, Math.min(fx.numProperties, args.toIndex));
+        e.moveTo(to);
+        // NOTE: `e` is invalidated after moveTo(); do not read from it afterwards.
+        return JSON.stringify({ status: "success", message: "Effect reordered", effect: effectName, newIndex: to }, null, 2);
+    } catch (error) {
+        return JSON.stringify({ status: "error", message: error.toString() }, null, 2);
+    }
+}
+
+// --- createLight: add a light layer ---
+function createLight(args) {
+    try {
+        var comp = mcpFindComp(args.compName || "");
+        if (!comp) { throw new Error("Composition not found"); }
+        var name = args.name || "Light";
+        var center = args.position ? [args.position[0], args.position[1]] : [comp.width / 2, comp.height / 2];
+        var light = comp.layers.addLight(name, center);
+        var lt = { "parallel": LightType.PARALLEL, "spot": LightType.SPOT, "point": LightType.POINT, "ambient": LightType.AMBIENT };
+        if (args.lightType && lt[args.lightType] !== undefined) { light.lightType = lt[args.lightType]; }
+
+        // User-supplied values must not fail silently: record any that don't apply.
+        var warnings = [];
+        if (args.position) {
+            try { light.property("Position").setValue(args.position); }
+            catch (e1) { warnings.push("position not applied: " + e1.toString()); }
+        }
+        if (args.pointOfInterest) {
+            try { light.property("Point of Interest").setValue(args.pointOfInterest); }
+            catch (e2) { warnings.push("pointOfInterest not applied: " + e2.toString()); }
+        }
+        var opts = light.property("ADBE Light Options Group");
+        if (opts) {
+            if (args.intensity !== undefined && args.intensity !== null) {
+                try { opts.property("ADBE Light Intensity").setValue(args.intensity); }
+                catch (e3) { warnings.push("intensity not applied: " + e3.toString()); }
+            }
+            if (args.color) {
+                try { opts.property("ADBE Light Color").setValue(args.color); }
+                catch (e4) { warnings.push("color not applied: " + e4.toString()); }
+            }
+        }
+        var lightResult = { status: "success", message: "Light created", name: light.name, index: light.index };
+        if (warnings.length) { lightResult.warnings = warnings; }
+        return JSON.stringify(lightResult, null, 2);
+    } catch (error) {
+        return JSON.stringify({ status: "error", message: error.toString() }, null, 2);
+    }
+}
+
+// --- set3DLayer: toggle a layer's 3D switch ---
+function set3DLayer(args) {
+    try {
+        var comp = mcpFindComp(args.compName || "");
+        if (!comp) { throw new Error("Composition not found"); }
+        var layer = mcpFindLayer(comp, args.layerIndex, args.layerName);
+        if (!layer) { throw new Error("Layer not found"); }
+        layer.threeDLayer = (args.enabled === undefined) ? true : !!args.enabled;
+        return JSON.stringify({ status: "success", message: "3D switch updated", layer: layer.name, threeD: layer.threeDLayer }, null, 2);
+    } catch (error) {
+        return JSON.stringify({ status: "error", message: error.toString() }, null, 2);
+    }
+}
+
+// --- renderComposition: render a comp via the Render Queue (blocking) ---
+function renderComposition(args) {
+    try {
+        var comp = mcpFindComp(args.compName || "");
+        if (!comp) { throw new Error("Composition not found"); }
+        if (!args.outPath) { throw new Error("outPath is required"); }
+        var rqItem = app.project.renderQueue.items.add(comp);
+        if (args.startTime !== undefined && args.startTime !== null) { rqItem.timeSpanStart = args.startTime; }
+        if (args.duration !== undefined && args.duration !== null) { rqItem.timeSpanDuration = args.duration; }
+        var om = rqItem.outputModule(1);
+        var warnings = [];
+        if (args.outputModuleTemplate) {
+            // Don't silently render with the wrong settings if the template name is bad.
+            try { om.applyTemplate(args.outputModuleTemplate); }
+            catch (et) { warnings.push("outputModuleTemplate '" + args.outputModuleTemplate + "' could not be applied; rendered with the default output module: " + et.toString()); }
+        }
+        om.file = new File(args.outPath);
+        app.project.renderQueue.render(); // blocking: freezes AE until the render finishes
+        var savedFile = om.file;
+        var savedPath = savedFile.fsName;
+        try { rqItem.remove(); } catch (er) {}
+        if (!savedFile.exists) {
+            throw new Error("Render reported complete but the output file was not created: " + savedPath);
+        }
+        var renderResult = { status: "success", message: "Render complete", path: savedPath, comp: comp.name };
+        if (warnings.length) { renderResult.warnings = warnings; }
+        return JSON.stringify(renderResult, null, 2);
+    } catch (error) {
+        return JSON.stringify({ status: "error", message: error.toString() }, null, 2);
+    }
+}
+
+// --- setKeyframeEase: apply temporal easing to existing keyframes of a property ---
+function setKeyframeEase(args) {
+    try {
+        var comp = mcpFindComp(args.compName || "");
+        if (!comp) { throw new Error("Composition not found"); }
+        var layer = mcpFindLayer(comp, args.layerIndex, args.layerName);
+        if (!layer) { throw new Error("Layer not found"); }
+        var prop = layer.property(args.propertyName);
+        if (!prop) { throw new Error("Property not found: " + args.propertyName); }
+        if (prop.numKeys === 0) { throw new Error("Property has no keyframes: " + args.propertyName); }
+        var influence = (args.influence !== undefined && args.influence !== null) ? args.influence : 33;
+        var easeType = args.easeType || "easyEase";
+        var sample = prop.keyValue(1);
+        var dim = (sample instanceof Array) ? sample.length : 1;
+        var keys = [];
+        if (args.keyIndex !== undefined && args.keyIndex !== null) { keys = [args.keyIndex]; }
+        else { for (var k = 1; k <= prop.numKeys; k++) { keys.push(k); } }
+        for (var ki = 0; ki < keys.length; ki++) {
+            var key = keys[ki];
+            if (easeType === "linear") {
+                prop.setInterpolationTypeAtKey(key, KeyframeInterpolationType.LINEAR, KeyframeInterpolationType.LINEAR);
+                continue;
+            }
+            // AE convention: "ease in" eases the incoming handle, "ease out" the outgoing.
+            // 0.1 is the minimum influence (~no ease) for the un-eased side.
+            var inInf = (easeType === "easeOut") ? 0.1 : influence;
+            var outInf = (easeType === "easeIn") ? 0.1 : influence;
+            var inEases = [], outEases = [];
+            for (var d = 0; d < dim; d++) {
+                inEases.push(new KeyframeEase(0, inInf));
+                outEases.push(new KeyframeEase(0, outInf));
+            }
+            prop.setInterpolationTypeAtKey(key, KeyframeInterpolationType.BEZIER, KeyframeInterpolationType.BEZIER);
+            prop.setTemporalEaseAtKey(key, inEases, outEases);
+        }
+        return JSON.stringify({ status: "success", message: "Keyframe ease applied", property: args.propertyName, keysAffected: keys.length, easeType: easeType }, null, 2);
+    } catch (error) {
+        return JSON.stringify({ status: "error", message: error.toString() }, null, 2);
+    }
+}
+
+// --- applyTrimPaths: add Trim Paths to a shape layer, optionally animate the "draw on" ---
+function applyTrimPaths(args) {
+    try {
+        var comp = mcpFindComp(args.compName || "");
+        if (!comp) { throw new Error("Composition not found"); }
+        var layer = mcpFindLayer(comp, args.layerIndex, args.layerName);
+        if (!layer) { throw new Error("Layer not found"); }
+        var contents = layer.property("ADBE Root Vectors Group");
+        if (!contents) { throw new Error("Layer is not a shape layer (no Contents)"); }
+        var trim = contents.addProperty("ADBE Vector Filter - Trim");
+        var startProp = trim.property("ADBE Vector Trim Start");
+        var endProp = trim.property("ADBE Vector Trim End");
+        var offsetProp = trim.property("ADBE Vector Trim Offset");
+        if (args.start !== undefined && args.start !== null) { startProp.setValue(args.start); }
+        if (args.offset !== undefined && args.offset !== null) { offsetProp.setValue(args.offset); }
+        if (args.drawOn) {
+            var from = (args.drawOn.from !== undefined) ? args.drawOn.from : 0;
+            var to = (args.drawOn.to !== undefined) ? args.drawOn.to : 100;
+            var st = (args.drawOn.startTime !== undefined) ? args.drawOn.startTime : 0;
+            var du = (args.drawOn.duration !== undefined) ? args.drawOn.duration : 1;
+            endProp.setValueAtTime(st, from);
+            endProp.setValueAtTime(st + du, to);
+        } else if (args.end !== undefined && args.end !== null) {
+            endProp.setValue(args.end);
+        }
+        return JSON.stringify({ status: "success", message: "Trim Paths applied", layer: layer.name }, null, 2);
+    } catch (error) {
+        return JSON.stringify({ status: "error", message: error.toString() }, null, 2);
+    }
+}
+
+// --- addTextAnimator: add a text animator with a range selector for per-character animation ---
+function addTextAnimator(args) {
+    try {
+        var comp = mcpFindComp(args.compName || "");
+        if (!comp) { throw new Error("Composition not found"); }
+        var layer = mcpFindLayer(comp, args.layerIndex, args.layerName);
+        if (!layer) { throw new Error("Layer not found"); }
+        var textProps = layer.property("ADBE Text Properties");
+        if (!textProps) { throw new Error("Layer is not a text layer"); }
+        var animators = textProps.property("ADBE Text Animators");
+        var animator = animators.addProperty("ADBE Text Animator");
+        if (args.name) { animator.name = args.name; }
+        var animProps = animator.property("ADBE Text Animator Properties");
+
+        var which = args.property || "opacity";
+        if (which === "opacity") {
+            animProps.addProperty("ADBE Text Opacity").setValue((args.value !== undefined) ? args.value : 0);
+        } else if (which === "position") {
+            animProps.addProperty("ADBE Text Position 3D").setValue(args.value || [0, -80, 0]);
+        } else if (which === "scale") {
+            animProps.addProperty("ADBE Text Scale 3D").setValue(args.value || [40, 40, 100]);
+        } else if (which === "rotation") {
+            animProps.addProperty("ADBE Text Rotation").setValue((args.value !== undefined) ? args.value : -30);
+        }
+
+        var selectors = animator.property("ADBE Text Selectors");
+        var sel = selectors.addProperty("ADBE Text Selector");
+        var offsetProp = sel.property("ADBE Text Percent Offset");
+        if (args.revealDuration) {
+            var st = (args.startTime !== undefined) ? args.startTime : 0;
+            offsetProp.setValueAtTime(st, -100);
+            offsetProp.setValueAtTime(st + args.revealDuration, 0);
+        } else if (args.offset !== undefined && args.offset !== null) {
+            offsetProp.setValue(args.offset);
+        }
+        return JSON.stringify({ status: "success", message: "Text animator added", layer: layer.name, animator: animator.name }, null, 2);
+    } catch (error) {
+        return JSON.stringify({ status: "error", message: error.toString() }, null, 2);
+    }
+}
+
+// --- saveProject: save the current project (optionally to a new path) ---
+function saveProject(args) {
+    try {
+        if (args && args.path) {
+            app.project.save(new File(args.path));
+        } else {
+            if (!app.project.file) { throw new Error("Project has never been saved; provide a 'path'"); }
+            app.project.save();
+        }
+        return JSON.stringify({ status: "success", message: "Project saved", path: app.project.file ? app.project.file.fsName : null }, null, 2);
+    } catch (error) {
+        return JSON.stringify({ status: "error", message: error.toString() }, null, 2);
+    }
+}
+
+// --- getLayerDetails: rich introspection of a single layer ---
+function getLayerDetails(args) {
+    try {
+        var comp = mcpFindComp(args.compName || "");
+        if (!comp) { throw new Error("Composition not found"); }
+        var layer = mcpFindLayer(comp, args.layerIndex, args.layerName);
+        if (!layer) { throw new Error("Layer not found"); }
+        var effects = [];
+        var fx = layer.property("ADBE Effect Parade");
+        if (fx) {
+            for (var i = 1; i <= fx.numProperties; i++) {
+                var e = fx.property(i);
+                effects.push({ index: i, name: e.name, matchName: e.matchName });
+            }
+        }
+        var masks = layer.property("ADBE Mask Parade");
+        var info = {
+            status: "success",
+            name: layer.name,
+            index: layer.index,
+            enabled: layer.enabled,
+            threeD: layer.threeDLayer === true,
+            blendingMode: layer.blendingMode,
+            parent: layer.parent ? layer.parent.name : null,
+            startTime: layer.startTime,
+            inPoint: layer.inPoint,
+            outPoint: layer.outPoint,
+            numMasks: masks ? masks.numProperties : 0,
+            effects: effects
+        };
+        return JSON.stringify(info, null, 2);
+    } catch (error) {
+        return JSON.stringify({ status: "error", message: error.toString() }, null, 2);
+    }
+}
+
 // --- setLayerProperties (modified to handle text properties) ---
 function setLayerProperties(args) {
     try {
@@ -1594,6 +2175,96 @@ function executeCommand(command, args) {
                 logToPanel("Calling setLayerMask function...");
                 result = setLayerMask(args);
                 logToPanel("Returned from setLayerMask.");
+                break;
+            case "saveFrame":
+                logToPanel("Calling saveFrame function...");
+                result = saveFrame(args);
+                logToPanel("Returned from saveFrame.");
+                break;
+            case "moveLayer":
+                logToPanel("Calling moveLayer function...");
+                result = moveLayer(args);
+                logToPanel("Returned from moveLayer.");
+                break;
+            case "importFootage":
+                logToPanel("Calling importFootage function...");
+                result = importFootage(args);
+                logToPanel("Returned from importFootage.");
+                break;
+            case "precompose":
+                logToPanel("Calling precompose function...");
+                result = precompose(args);
+                logToPanel("Returned from precompose.");
+                break;
+            case "setLayerParent":
+                logToPanel("Calling setLayerParent function...");
+                result = setLayerParent(args);
+                logToPanel("Returned from setLayerParent.");
+                break;
+            case "createNull":
+                logToPanel("Calling createNull function...");
+                result = createNull(args);
+                logToPanel("Returned from createNull.");
+                break;
+            case "setBlendMode":
+                logToPanel("Calling setBlendMode function...");
+                result = setBlendMode(args);
+                logToPanel("Returned from setBlendMode.");
+                break;
+            case "setTrackMatte":
+                logToPanel("Calling setTrackMatte function...");
+                result = setTrackMatte(args);
+                logToPanel("Returned from setTrackMatte.");
+                break;
+            case "removeEffect":
+                logToPanel("Calling removeEffect function...");
+                result = removeEffect(args);
+                logToPanel("Returned from removeEffect.");
+                break;
+            case "reorderEffect":
+                logToPanel("Calling reorderEffect function...");
+                result = reorderEffect(args);
+                logToPanel("Returned from reorderEffect.");
+                break;
+            case "createLight":
+                logToPanel("Calling createLight function...");
+                result = createLight(args);
+                logToPanel("Returned from createLight.");
+                break;
+            case "set3DLayer":
+                logToPanel("Calling set3DLayer function...");
+                result = set3DLayer(args);
+                logToPanel("Returned from set3DLayer.");
+                break;
+            case "renderComposition":
+                logToPanel("Calling renderComposition function...");
+                result = renderComposition(args);
+                logToPanel("Returned from renderComposition.");
+                break;
+            case "setKeyframeEase":
+                logToPanel("Calling setKeyframeEase function...");
+                result = setKeyframeEase(args);
+                logToPanel("Returned from setKeyframeEase.");
+                break;
+            case "applyTrimPaths":
+                logToPanel("Calling applyTrimPaths function...");
+                result = applyTrimPaths(args);
+                logToPanel("Returned from applyTrimPaths.");
+                break;
+            case "addTextAnimator":
+                logToPanel("Calling addTextAnimator function...");
+                result = addTextAnimator(args);
+                logToPanel("Returned from addTextAnimator.");
+                break;
+            case "saveProject":
+                logToPanel("Calling saveProject function...");
+                result = saveProject(args);
+                logToPanel("Returned from saveProject.");
+                break;
+            case "getLayerDetails":
+                logToPanel("Calling getLayerDetails function...");
+                result = getLayerDetails(args);
+                logToPanel("Returned from getLayerDetails.");
                 break;
             default:
                 result = JSON.stringify({ error: "Unknown command: " + command });


### PR DESCRIPTION
## Summary

Adds 18 new MCP tools (and matching bridge functions) that fill common gaps for motion-graphics work. All changes are **purely additive** and backward compatible — no existing tools were modified.

Each tool is wired through the existing file-based bridge: a `server.tool` registration in `src/index.ts` that queues a command, plus a handler function + switch case in `src/scripts/mcp-bridge-auto.jsx`, plus an entry in the `run-script` allowlist.

## New tools

**Layers / rigging**
- `move-layer` – reorder a layer (front / back / before / after / to-index)
- `set-parent` – set or clear a layer's parent
- `create-null` – create a null object
- `set-3d-layer` – toggle a layer's 3D switch

**Compositing**
- `set-blend-mode` – set a layer's blending mode
- `set-track-matte` – set/clear a track matte (optionally to a specific layer)

**Effects**
- `remove-effect`, `reorder-effect`

**3D**
- `create-light` – parallel / spot / point / ambient

**Animation quality**
- `set-keyframe-ease` – easy-ease / ease-in / ease-out on existing keyframes
- `apply-trim-paths` – Trim Paths on a shape, incl. animated "draw-on"
- `add-text-animator` – text animator + range selector (per-character)

**Project / IO**
- `import-footage`, `precompose`, `save-project`

**Output / inspection**
- `render-video` – render a comp via the render queue
- `save-frame` – render a single frame to PNG (lets an AI assistant inspect results)
- `get-layer-details` – effects list, blend mode, parent, 3D, timing

## Error-handling / robustness

- `mcpFindComp` no longer silently falls back to the active comp when a non-empty `compName` is supplied but unmatched (prevents mutating the wrong composition).
- `create-light` / `render-video` surface non-fatal issues via a `warnings[]` field instead of swallowing them.
- `set-track-matte` errors if a requested matte layer can't be resolved, and reports when the legacy `trackMatteType` path was used.
- `save-frame` / `render-video` verify the output file was actually written.
- `precompose` guards the single-layer-only constraint of `moveAllAttributes`.

## Testing

Manually verified end-to-end against **After Effects 2026 (v26.2.0, Japanese UI)** on Windows: each of the 18 tools was executed through the bridge and its result confirmed. `render-video` produced a real `.mp4` and `save-frame` produced a PNG that was inspected.

## Notes

- README updated to document the new tools.
- `render-video` output format depends on the chosen/default output module template (the default is H.264 `.mp4` on some installs, including AE 26.2.0 here).
