### PR TITLE
Reliability: fix result correlation (ES3 toISOString) + read-only bridge-status probe

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,27 @@ Go to your client (e.g., Claude or Cursor) and update your config file:
 }
 ```
 
+#### Optional: `AE_MCP_BRIDGE_DIR`
+By default the server and the bridge panel exchange files in `~/Documents/ae-mcp-bridge`.
+Set the `AE_MCP_BRIDGE_DIR` environment variable to point both sides at a custom folder —
+useful when the MCP host and After Effects run in different OS contexts (for example, Node
+in WSL driving After Effects on Windows) and need to rendezvous on a shared path:
+
+```json
+{
+  "mcpServers": {
+    "AfterEffectsMCP": {
+      "command": "node",
+      "args": ["PATH/TO/after-effects-mcp/build/index.js"],
+      "env": { "AE_MCP_BRIDGE_DIR": "/mnt/c/Users/you/Documents/ae-mcp-bridge" }
+    }
+  }
+}
+```
+
+The panel honors the same variable from After Effects' own environment; when it is unset,
+the `~/Documents/ae-mcp-bridge` default must resolve to the same physical folder on both sides.
+
 ### ▶️ Running the Server
 
 1. **Start the MCP server**
@@ -205,6 +226,7 @@ You can animate layers with:
 | `run-script`                | Run a JS script inside AE              |
 | `get-results`               | Get script results                     |
 | `get-help`                  | Help for available commands            |
+| `bridge-status`             | Read-only liveness probe: is the panel open and responding? |
 | `setLayerKeyframe`          | Add keyframe to layer property         |
 | `setLayerExpression`        | Add/remove expressions from properties|
 | `setLayerProperties`        | Set layer properties (position, scale, rotation, opacity, blendMode, threeDLayer, trackMatteType, enabled, etc.) |

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,16 +21,26 @@ const __dirname = path.dirname(__filename);
 const SCRIPTS_DIR = path.join(__dirname, "scripts");
 const TEMP_DIR = path.join(__dirname, "temp");
 
-// Get the correct directory for AE bridge files
-// Use ~/Documents/ae-mcp-bridge for reliable cross-process access
+// Get the correct directory for AE bridge files.
+// Defaults to ~/Documents/ae-mcp-bridge. Set AE_MCP_BRIDGE_DIR to override when the
+// MCP host and After Effects run in different OS contexts (for example, Node in WSL
+// driving Windows After Effects) and must rendezvous on a shared path.
 function getAETempDir(): string {
-  const homeDir = os.homedir();
-  const bridgeDir = path.join(homeDir, 'Documents', 'ae-mcp-bridge');
+  const bridgeDir = process.env.AE_MCP_BRIDGE_DIR || path.join(os.homedir(), 'Documents', 'ae-mcp-bridge');
   // Ensure the directory exists
   if (!fs.existsSync(bridgeDir)) {
     fs.mkdirSync(bridgeDir, { recursive: true });
   }
   return bridgeDir;
+}
+
+// Monotonic id stamped on every queued command so a result can be correlated back to
+// the exact request that produced it. The panel echoes it back as `_commandId`.
+let commandCounter = 0;
+let lastCommandId: string | null = null;
+function nextCommandId(): string {
+  commandCounter += 1;
+  return `${Date.now()}-${commandCounter}`;
 }
 
 // Headless CLI execution has been removed. All interactions are routed through the Bridge panel.
@@ -50,19 +60,33 @@ function readResultsFromTempFile(): string {
       
       const content = fs.readFileSync(tempFilePath, 'utf8');
       console.error(`Result file content length: ${content.length} bytes`);
-      
-      // If the result file is older than 30 seconds, warn the user
-      const thirtySecondsAgo = new Date(Date.now() - 30 * 1000);
-      if (stats.mtime < thirtySecondsAgo) {
-        console.error(`WARNING: Result file is older than 30 seconds. After Effects may not be updating results.`);
-        return JSON.stringify({ 
-          warning: "Result file appears to be stale (not recently updated).",
-          message: "This could indicate After Effects is not properly writing results or the MCP Bridge Auto panel isn't running.",
-          lastModified: stats.mtime.toISOString(),
-          originalContent: content
-        });
+
+      // Correlate by commandId instead of wall-clock mtime. The panel echoes the
+      // queued command's `_commandId` onto each result; if it doesn't match the last
+      // command we sent, the result belongs to an earlier request. mtime is unreliable
+      // here — the bridge dir is often a shared/mounted path (e.g. WSL /mnt/c) where
+      // clock skew and simple re-reads trip a naive "older than N seconds" check on
+      // perfectly correct data. If the panel predates this field (`_commandId` absent),
+      // fall through and return the content as-is rather than crying stale.
+      if (lastCommandId) {
+        try {
+          const parsed = JSON.parse(content);
+          if (parsed && typeof parsed === 'object' && '_commandId' in parsed && parsed._commandId !== lastCommandId) {
+            console.error(`Result commandId (${parsed._commandId}) != last queued (${lastCommandId}).`);
+            return JSON.stringify({
+              warning: "Result is from an earlier command (commandId mismatch).",
+              message: "After Effects has not yet written the result for the most recent command. Ensure the MCP Bridge Auto panel is open and call get-results again shortly.",
+              expectedCommandId: lastCommandId,
+              resultCommandId: parsed._commandId,
+              lastModified: stats.mtime.toISOString(),
+              originalContent: content
+            }, null, 2);
+          }
+        } catch {
+          // Not valid JSON yet (panel may be mid-write); return raw content below.
+        }
       }
-      
+
       return content;
     } else {
       console.error(`Result file not found at: ${tempFilePath}`);
@@ -74,8 +98,10 @@ function readResultsFromTempFile(): string {
   }
 }
 
-// Helper to wait for a fresh result produced by a specific command
-async function waitForBridgeResult(expectedCommand?: string, timeoutMs: number = 5000, pollMs: number = 250): Promise<string> {
+// Helper to wait for the fresh result produced by a specific queued command, matched
+// by its unique commandId (see nextCommandId / writeCommandFile). Pass the id returned
+// by writeCommandFile; omit it to accept the next result of any command.
+async function waitForBridgeResult(expectedCommandId?: string, timeoutMs: number = 5000, pollMs: number = 250): Promise<string> {
   const start = Date.now();
   const resultPath = path.join(getAETempDir(), 'ae_mcp_result.json');
   let lastSize = -1;
@@ -88,7 +114,7 @@ async function waitForBridgeResult(expectedCommand?: string, timeoutMs: number =
           lastSize = content.length;
           try {
             const parsed = JSON.parse(content);
-            if (!expectedCommand || parsed._commandExecuted === expectedCommand) {
+            if (!expectedCommandId || parsed._commandId === expectedCommandId) {
               return content;
             }
           } catch {
@@ -101,24 +127,29 @@ async function waitForBridgeResult(expectedCommand?: string, timeoutMs: number =
     }
     await new Promise(r => setTimeout(r, pollMs));
   }
-  return JSON.stringify({ error: `Timed out waiting for bridge result${expectedCommand ? ` for command '${expectedCommand}'` : ''}.` });
+  return JSON.stringify({ error: `Timed out waiting for bridge result${expectedCommandId ? ` for commandId '${expectedCommandId}'` : ''}.` });
 }
 
-// Helper function to write command to file
-function writeCommandFile(command: string, args: Record<string, any> = {}): void {
+// Helper function to write command to file. Returns the unique commandId stamped on
+// this request; pass it to waitForBridgeResult to await the matching result.
+function writeCommandFile(command: string, args: Record<string, any> = {}): string {
+  const commandId = nextCommandId();
   try {
     const commandFile = path.join(getAETempDir(), 'ae_command.json');
     const commandData = {
       command,
       args,
+      commandId,
       timestamp: new Date().toISOString(),
       status: "pending"  // pending, running, completed, error
     };
     fs.writeFileSync(commandFile, JSON.stringify(commandData, null, 2));
-    console.error(`Command "${command}" written to ${commandFile}`);
+    lastCommandId = commandId;
+    console.error(`Command "${command}" (${commandId}) written to ${commandFile}`);
   } catch (error) {
     console.error("Error writing command file:", error);
   }
+  return commandId;
 }
 
 // Helper function to clear the results file to avoid stale cache
@@ -147,8 +178,8 @@ server.resource(
   async (uri) => {
     // Clear old results, queue the command, and wait for bridge output
     clearResultsFile();
-    writeCommandFile("listCompositions", {});
-    const result = await waitForBridgeResult("listCompositions", 6000, 250);
+    const commandId = writeCommandFile("listCompositions", {});
+    const result = await waitForBridgeResult(commandId, 6000, 250);
 
     return {
       contents: [{
@@ -943,6 +974,56 @@ server.tool(
         isError: true
       };
     }
+  }
+);
+
+// Read-only liveness probe. Confirms the "MCP Bridge Auto" panel is open and polling
+// and reports round-trip latency plus basic project context — WITHOUT mutating the
+// project (unlike run-bridge-test, which applies effects). Use this as the first
+// diagnostic when results stop coming back: the panel is not headless and closes on
+// every After Effects restart, so a silent "pending" almost always means it's closed.
+server.tool(
+  "bridge-status",
+  "Check whether the After Effects MCP Bridge Auto panel is open and responding (read-only liveness probe; does not modify the project).",
+  {
+    timeoutMs: z.number().int().positive().optional().describe("How long to wait for the panel to respond, in ms (default 4000).")
+  },
+  async ({ timeoutMs = 4000 }) => {
+    const start = Date.now();
+    clearResultsFile();
+    const commandId = writeCommandFile("ping", {});
+    const raw = await waitForBridgeResult(commandId, timeoutMs, 200);
+    const roundTripMs = Date.now() - start;
+
+    let responsive = false;
+    let parsed: any = null;
+    try {
+      parsed = JSON.parse(raw);
+      responsive = !!parsed && parsed._commandId === commandId && !parsed.error;
+    } catch {
+      // fall through as unresponsive
+    }
+
+    const report = responsive
+      ? {
+          panelResponsive: true,
+          roundTripMs,
+          bridgeDir: getAETempDir(),
+          aeVersion: parsed.aeVersion,
+          project: parsed.project,
+          activeComp: parsed.activeComp
+        }
+      : {
+          panelResponsive: false,
+          roundTripMs,
+          bridgeDir: getAETempDir(),
+          hint: "No fresh response from the bridge panel. In After Effects open Window > mcp-bridge-auto.jsx (it must be reopened after every AE restart) and make sure 'Auto-run commands' is checked. On AE 2025+ it can only be a floating window.",
+          detail: parsed || raw
+        };
+
+    return {
+      content: [{ type: "text", text: JSON.stringify(report, null, 2) }]
+    };
   }
 );
 

--- a/src/scripts/mcp-bridge-auto.jsx
+++ b/src/scripts/mcp-bridge-auto.jsx
@@ -1281,6 +1281,25 @@ if (typeof JSON.stringify !== "function") {
     })();
 }
 
+// toISOString polyfill for ExtendScript. ExtendScript's Date is ES3 and has NO
+// toISOString, so `new Date().toISOString()` throws. Where that call sits inside a
+// try/catch (as when stamping the result file), the throw is swallowed and the result
+// is written WITHOUT its correlation fields — which made the MCP unable to tell a fresh
+// result from an old one. Defining it here makes the stamping succeed.
+if (typeof Date.prototype.toISOString !== "function") {
+    Date.prototype.toISOString = function () {
+        function pad(n) { return (n < 10 ? "0" : "") + n; }
+        function pad3(n) { return (n < 10 ? "00" : (n < 100 ? "0" : "")) + n; }
+        return this.getUTCFullYear() + "-" +
+            pad(this.getUTCMonth() + 1) + "-" +
+            pad(this.getUTCDate()) + "T" +
+            pad(this.getUTCHours()) + ":" +
+            pad(this.getUTCMinutes()) + ":" +
+            pad(this.getUTCSeconds()) + "." +
+            pad3(this.getUTCMilliseconds()) + "Z";
+    };
+}
+
 // Detect AE version (AE 2025 = version 25.x, AE 2026 = version 26.x)
 var aeVersion = parseFloat(app.version);
 var isAE2025OrLater = aeVersion >= 25.0;
@@ -1317,24 +1336,35 @@ autoRunCheckbox.value = true;
 var checkInterval = 2000;
 var isChecking = false;
 
-// Command file path - use Documents folder for reliable access
-function getCommandFilePath() {
-    var userFolder = Folder.myDocuments;
-    var bridgeFolder = new Folder(userFolder.fsName + "/ae-mcp-bridge");
+// Resolve the shared bridge folder. Honors the AE_MCP_BRIDGE_DIR environment variable
+// (read from the After Effects process) so both sides can rendezvous on a custom path,
+// and otherwise falls back to ~/Documents/ae-mcp-bridge. Note: on a split setup (e.g.
+// Node in WSL, AE on Windows) the two processes have separate environments, so this
+// only takes effect if AE's OWN environment defines the variable; when it isn't set,
+// the Documents default must resolve to the same physical folder on both sides.
+function getBridgeFolder() {
+    var custom = null;
+    try { custom = $.getenv("AE_MCP_BRIDGE_DIR"); } catch (e) { custom = null; }
+    var bridgeFolder;
+    if (custom && ("" + custom).length > 0) {
+        bridgeFolder = new Folder(custom);
+    } else {
+        bridgeFolder = new Folder(Folder.myDocuments.fsName + "/ae-mcp-bridge");
+    }
     if (!bridgeFolder.exists) {
         bridgeFolder.create();
     }
-    return bridgeFolder.fsName + "/ae_command.json";
+    return bridgeFolder;
 }
 
-// Result file path - use Documents folder for reliable access
+// Command file path
+function getCommandFilePath() {
+    return getBridgeFolder().fsName + "/ae_command.json";
+}
+
+// Result file path
 function getResultFilePath() {
-    var userFolder = Folder.myDocuments;
-    var bridgeFolder = new Folder(userFolder.fsName + "/ae-mcp-bridge");
-    if (!bridgeFolder.exists) {
-        bridgeFolder.create();
-    }
-    return bridgeFolder.fsName + "/ae_mcp_result.json";
+    return getBridgeFolder().fsName + "/ae_mcp_result.json";
 }
 
 // --- setCompositionProperties: set duration, frameRate, etc. on active or named comp ---
@@ -1495,7 +1525,7 @@ function getLayerInfo() {
 }
 
 // Execute command
-function executeCommand(command, args) {
+function executeCommand(command, args, commandId) {
     var result = "";
 
     logToPanel("Executing command: " + command);
@@ -1595,6 +1625,9 @@ function executeCommand(command, args) {
                 result = setLayerMask(args);
                 logToPanel("Returned from setLayerMask.");
                 break;
+            case "ping":
+                result = pingBridge();
+                break;
             default:
                 result = JSON.stringify({ error: "Unknown command: " + command });
         }
@@ -1604,18 +1637,18 @@ function executeCommand(command, args) {
         logToPanel("Preparing to write result file...");
         var resultString = (typeof result === 'string') ? result : JSON.stringify(result);
         
-        // Try to parse the result as JSON to add a timestamp
+        // Try to parse the result as JSON to add correlation metadata
         try {
             var resultObj = JSON.parse(resultString);
-            // Add a timestamp to help identify if we're getting fresh results
+            // Stamp the result so the MCP side can correlate it to the exact request.
             resultObj._responseTimestamp = new Date().toISOString();
             resultObj._commandExecuted = command;
+            resultObj._commandId = commandId;
             resultString = JSON.stringify(resultObj, null, 2);
-            logToPanel("Added timestamp to result JSON for tracking freshness.");
+            logToPanel("Stamped result with commandId " + commandId + " for correlation.");
         } catch (parseError) {
-            // If it's not valid JSON, append the timestamp as a comment
-            logToPanel("Could not parse result as JSON to add timestamp: " + parseError.toString());
-            // We'll still continue with the original string
+            // If it's not valid JSON, continue with the original string
+            logToPanel("Could not parse result as JSON to add correlation metadata: " + parseError.toString());
         }
         
         var resultFile = new File(getResultFilePath());
@@ -1656,9 +1689,10 @@ function executeCommand(command, args) {
         // Write detailed error to result file
         try {
             logToPanel("Attempting to write ERROR to result file...");
-            var errorResult = JSON.stringify({ 
-                status: "error", 
+            var errorResult = JSON.stringify({
+                status: "error",
                 command: command,
+                _commandId: commandId,
                 message: error.toString(),
                 line: error.line,
                 fileName: error.fileName
@@ -1712,6 +1746,22 @@ function logToPanel(message) {
     logText.text = timestamp + ": " + message + "\n" + logText.text;
 }
 
+// Lightweight read-only liveness response for the bridge-status MCP tool. Reports the
+// AE version and active-composition context without touching the project (contrast with
+// bridgeTestEffects, which mutates). Function declarations are hoisted, so definition
+// order relative to the switch does not matter.
+function pingBridge() {
+    var info = { status: "success", pong: true, aeVersion: app.version };
+    try { info.project = app.project.file ? app.project.file.name : "Untitled Project"; } catch (e) {}
+    try {
+        if (app.project.activeItem instanceof CompItem) {
+            var ac = app.project.activeItem;
+            info.activeComp = { name: ac.name, width: ac.width, height: ac.height, numLayers: ac.numLayers };
+        }
+    } catch (e2) {}
+    return JSON.stringify(info, null, 2);
+}
+
 // Check for new commands
 function checkForCommands() {
     if (!autoRunCheckbox.value || isChecking) return;
@@ -1734,9 +1784,9 @@ function checkForCommands() {
                 if (commandData.status === "pending") {
                     // Update status to running
                     updateCommandStatus("running");
-                    
-                    // Execute the command
-                    executeCommand(commandData.command, commandData.args || {});
+
+                    // Execute the command (pass commandId through for result correlation)
+                    executeCommand(commandData.command, commandData.args || {}, commandData.commandId);
                 }
             }
         }


### PR DESCRIPTION
## Summary

The file-based bridge couldn't reliably tell a **fresh** result from an **old** one, which made the very first "is this even working?" diagnosis painful. This PR fixes the root causes and adds a read-only way to confirm the panel is alive. All changes are backward-compatible.

## What was broken

1. **`toISOString` throws in ExtendScript.** The panel stamps each result via `new Date().toISOString()`, but ExtendScript's `Date` is ES3 and has **no** `toISOString`. The call throws, the surrounding `try/catch` swallows it, and the result is written **without** its correlation fields (`_commandExecuted`, `_responseTimestamp`). That silently broke `waitForBridgeResult()`, which matches on `_commandExecuted` — so, for example, the `compositions` resource could only ever time out.
2. **Staleness was judged by wall-clock mtime.** `get-results` returned `"Result file appears to be stale"` whenever the result file's mtime was more than 30s old. On a shared/mounted bridge dir (e.g. WSL `/mnt/c` driving Windows AE) clock skew and simple re-reads trip that on **perfectly correct data**.
3. **No read-only liveness check.** The only "is the panel alive?" tool, `run-bridge-test`, **applies effects** to the open project.

## Changes

- **Add an ES3 `toISOString` polyfill** in the panel so result-stamping succeeds.
- **Correlate results to requests by a per-command `commandId`** (echoed back by the panel as `_commandId`) instead of wall-clock mtime. `get-results` and `waitForBridgeResult` now match on it, and the false "stale" path is gone. If the panel predates the field, it falls back gracefully to returning the raw content.
- **Add `bridge-status`** — a read-only liveness probe (`ping`) that reports whether the panel is open and its round-trip latency, **without** mutating the project.
- **Support `AE_MCP_BRIDGE_DIR`** so the server and panel can rendezvous on a shared folder when the MCP host and After Effects run in different OS contexts (WSL ↔ Windows). The panel honours the same variable via `$.getenv`.

## Testing

`npm run build` (esbuild) passes; the panel `.jsx` passes a syntax parse. The bridge round-trip and `bridge-status` were exercised against After Effects 2024 on Windows, driven from Node in WSL.

## Notes

A companion PR (community tool bundle) lives in a separate branch to keep this one focused on reliability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
