### PR TITLE
fix: setLayerKeyframe fails for array-valued properties (Scale/Position)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -439,9 +439,31 @@ const LayerIdentifierSchema = {
   layerIndex: z.number().int().positive().describe("1-based index of the target layer within the composition.")
 };
 
-// Zod schema for keyframe value (more specific types might be needed depending on property)
-// Using z.any() for flexibility, but can be refined (e.g., z.array(z.number()) for position/scale)
-const KeyframeValueSchema = z.unknown().describe("The value for the keyframe (e.g., [x,y] for Position, [w,h] for Scale, angle for Rotation, percentage for Opacity)");
+// Zod schema for keyframe value: a scalar (Opacity, Rotation), an array of
+// numbers (Position, Scale), or a string form of either that some MCP clients
+// send because this parameter used to be untyped.
+const KeyframeValueSchema = z.union([
+  z.number(),
+  z.array(z.number()),
+  z.string()
+]).describe("The value for the keyframe (e.g., [x,y] for Position, [w,h] for Scale, angle for Rotation, percentage for Opacity)");
+
+// Parse keyframe values that arrive as JSON strings (e.g. "[1600,1600]" or "50")
+// so the ExtendScript bridge always receives a real array/number — AE's
+// setValueAtTime rejects strings for array-valued properties like Scale.
+function normalizeKeyframeValue(value: unknown): unknown {
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (/^\[[\d\s.,\-eE]*\]$/.test(trimmed) || /^-?\d+(\.\d+)?$/.test(trimmed)) {
+      try {
+        return JSON.parse(trimmed);
+      } catch {
+        // Leave as-is; the bridge reports the error
+      }
+    }
+  }
+  return value;
+}
 
 // Tool for setting a layer keyframe
 server.tool(
@@ -456,7 +478,7 @@ server.tool(
   async (parameters) => {
     try {
       // Queue the command for After Effects
-      writeCommandFile("setLayerKeyframe", parameters);
+      writeCommandFile("setLayerKeyframe", { ...parameters, value: normalizeKeyframeValue(parameters.value) });
       
       return {
         content: [

--- a/src/scripts/mcp-bridge-auto.jsx
+++ b/src/scripts/mcp-bridge-auto.jsx
@@ -741,6 +741,56 @@ function batchSetLayerProperties(args) {
 }
 
 /**
+ * Normalizes a keyframe value against the target property's current value.
+ * MCP clients sometimes deliver array values as JSON strings (e.g. "[1600,1600]"),
+ * and callers may pass 2D values for 3D properties (or vice versa) or a scalar
+ * for a multi-dimensional property like Scale.
+ * @param {Property} property - The AE property the value will be applied to.
+ * @param {any} value - The raw value from the command args.
+ * @returns {any} A value whose shape matches the property (array of the right length, or scalar).
+ */
+function normalizeKeyframeValue(property, value) {
+    // Parse values that arrived as strings, e.g. "[1600,1600]" or "50"
+    if (typeof value === "string") {
+        var trimmed = value.replace(/^\s+|\s+$/g, "");
+        if (/^\[[\d\s.,\-eE]*\]$/.test(trimmed) || /^-?\d+(\.\d+)?$/.test(trimmed)) {
+            try {
+                value = JSON.parse(trimmed);
+            } catch (parseErr) {
+                // Leave as-is; AE will report the type error
+            }
+        }
+    }
+
+    var current = property.value;
+    if (current instanceof Array) {
+        // Multi-dimensional property (Position, Scale, Anchor Point, ...)
+        if (!(value instanceof Array)) {
+            if (typeof value === "number") {
+                // Uniform expansion: 160 -> [160,160] or [160,160,160]
+                var uniform = [];
+                for (var i = 0; i < current.length; i++) {
+                    uniform.push(value);
+                }
+                value = uniform;
+            }
+        } else if (value.length !== current.length) {
+            // 2D value on a 3D property (or vice versa): pad missing
+            // dimensions from the current value (preserves z), drop extras.
+            var adjusted = value.slice(0, current.length);
+            for (var d = adjusted.length; d < current.length; d++) {
+                adjusted.push(current[d]);
+            }
+            value = adjusted;
+        }
+    } else if (typeof current === "number" && value instanceof Array && value.length > 0) {
+        // Scalar property (Opacity, Rotation) given a one-element array
+        value = value[0];
+    }
+    return value;
+}
+
+/**
  * Sets a keyframe for a specific property on a layer.
  * Indices are 1-based for After Effects collections.
  * @param {number} compIndex - The index of the composition (1-based).
@@ -792,7 +842,7 @@ function setLayerKeyframe(compIndex, layerIndex, propertyName, timeInSeconds, va
              property.setValueAtTime(comp.time, property.value); // Set initial keyframe if none exist
         }
 
-
+        value = normalizeKeyframeValue(property, value);
         property.setValueAtTime(timeInSeconds, value);
 
         return JSON.stringify({ success: true, message: "Keyframe set for '" + propertyName + "' on layer '" + layer.name + "' at " + timeInSeconds + "s." });


### PR DESCRIPTION
## Problem

`setLayerKeyframe` fails for any array-valued property (Scale, Position, Anchor Point). Scalar properties like Opacity work fine.

```
Error setting keyframe: Error: After Effects error: Unable to call "setValueAtTime"
because of parameter 2. Value is not an array. (Line: 796)
```

Reproduced on After Effects 2026 (v26.x) on Windows, calling the `setLayerKeyframe` tool with `propertyName: "Scale"` and `value: [1600, 1600]`.

## Root cause

The `value` parameter is declared as `z.unknown()`:

```ts
const KeyframeValueSchema = z.unknown().describe("The value for the keyframe (...)");
```

Because the schema carries no type information, MCP clients are free to serialize the argument as a plain string. In practice they do — calling the tool with a genuine array `[1600, 1600]` produced this in `ae_command.json`:

```json
"value": "[1600, 1600]"
```

The bridge then hands that string straight to `property.setValueAtTime(time, value)`, and After Effects rejects it because a multi-dimensional property requires an array. The bridge itself was never broken for real arrays — a hand-written command file containing a true JSON array sets the keyframe correctly. The failure is entirely in how the value is typed and carried across the boundary.

## Fix

Two layers, so the bug is fixed regardless of which side is updated first (a user with an old bridge panel still in memory, or an old server process, is common given the panel must be manually reloaded):

**`src/index.ts`** — `KeyframeValueSchema` is now a typed union (`number | number[] | string`) so clients see a real type and generally send a proper array. Values that still arrive as JSON strings are parsed before the command file is written.

**`src/scripts/mcp-bridge-auto.jsx`** — new `normalizeKeyframeValue(property, value)` reconciles the incoming value with the target property's actual shape:

- parses stringified values (`"[1600,1600]"`, `"50"`)
- expands a scalar to a uniform array for multi-dimensional properties (`90` → `[90, 90, 90]`), which makes uniform Scale keyframes much less awkward to write
- pads or truncates 2D/3D mismatches using the property's current value, so passing `[x, y]` to a 3D layer's Position preserves the existing z instead of erroring
- collapses a one-element array to a scalar for Opacity/Rotation
- leaves anything unrecognized untouched, so genuine type errors still surface from AE rather than being silently swallowed

## Testing

- 12 unit cases against the extracted `normalizeKeyframeValue` covering string arrays, 2D↔3D padding and truncation, scalar expansion, negative and exponent-notation numbers, and non-JSON strings passing through unchanged.
- Executed inside a live After Effects 2026 instance against real `Property` objects: `"[1600,1600]"` on a 3D-shaped Scale resolves to `[1600, 1600, 100]` and sets the keyframe; scalar `90` resolves to `[90, 90, 90]`.
- End-to-end through the MCP tool with the rebuilt bridge: `setLayerKeyframe` with `value: [1600, 1600]` on a text layer now returns `{"success": true, "message": "Keyframe set for 'Scale' ..."}` where it previously returned the line-796 error.

No behavior change for values that were already correctly shaped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
