### PR TITLE
Detect the After Effects Beta install on macOS

### DIFF
--- a/install-bridge.js
+++ b/install-bridge.js
@@ -18,6 +18,7 @@ const possiblePaths = isMac
   ? [
       '/Applications/Adobe After Effects 2026',
       '/Applications/Adobe After Effects 2025',
+      '/Applications/Adobe After Effects (Beta)',
       '/Applications/Adobe After Effects 2024',
       '/Applications/Adobe After Effects 2023',
       '/Applications/Adobe After Effects 2022',


### PR DESCRIPTION
## Summary

`npm run install-bridge` fails on macOS machines where the After Effects Beta is the only build installed.

`install-bridge.js` probes a fixed list of `/Applications/Adobe After Effects 20XX` paths. The Beta installs to `/Applications/Adobe After Effects (Beta)` instead, so no candidate matches, and the script exits 1 with "Could not find After Effects installation" and a request to copy the panel by hand.

The Beta is a normal install for anyone tracking new AE features, and its `Scripts/ScriptUI Panels` folder works exactly like a release build's.

## Change

One line: add the Beta path to the macOS candidate list.

```js
const possiblePaths = isMac
  ? [
      '/Applications/Adobe After Effects 2026',
      '/Applications/Adobe After Effects 2025',
+     '/Applications/Adobe After Effects (Beta)',
      '/Applications/Adobe After Effects 2024',
      ...
```

It sits below the numbered releases deliberately, so on a machine with both a release build and the Beta the release still wins and behaviour is unchanged.

## Testing

Verified on macOS 15 (Darwin 25.5.0) with After Effects Beta as the only install, Node 24.11.1.

- Before: exits 1, "Could not find After Effects installation."
- After: resolves `/Applications/Adobe After Effects (Beta)/Scripts/ScriptUI Panels` and installs the panel there. AE picks it up under `Window > mcp-bridge-auto.jsx`.

No change on a machine with a numbered release, since those entries are matched first.

## Note on overlap

I checked the other open PRs before filing. #14 restructures this same `possiblePaths` list into a per-platform object but does not add the Beta path, so if #14 lands first this becomes a one-line addition to `possiblePaths.darwin`. Happy to rebase it either way, or to close this if you would rather fold it into #14.