### PR TITLE
fix: 6 bridge/scripting bugs found via live AE testing

### DIFF
--- a/install-bridge.js
+++ b/install-bridge.js
@@ -91,11 +91,26 @@ try {
       execSync(`sudo cp "${sourceScript}" "${destinationScript}"`, { stdio: 'inherit' });
     }
   } else {
-    // Try to use PowerShell with elevated privileges on Windows
-    const command = `
-      Start-Process PowerShell -Verb RunAs -ArgumentList "-Command Copy-Item -Path '${sourceScript.replace(/\\/g, '\\\\')}' -Destination '${destinationScript.replace(/\\/g, '\\\\')}' -Force"
-    `;
-    execSync(`powershell -Command "${command}"`, { stdio: 'inherit' });
+    // On Windows, try a direct copy first (many installs allow this without
+    // elevation). Only fall back to an elevated PowerShell if that fails.
+    try {
+      fs.copyFileSync(sourceScript, destinationScript);
+    } catch {
+      // Start-Process -Verb RunAs launches asynchronously, so we must pass
+      // -Wait or this script would report success before the elevated copy
+      // has actually run. We also verify the file afterward since the user
+      // can dismiss the UAC prompt without it surfacing as an error here.
+      const command = `
+        Start-Process PowerShell -Verb RunAs -Wait -ArgumentList "-Command Copy-Item -Path '${sourceScript.replace(/\\/g, '\\\\')}' -Destination '${destinationScript.replace(/\\/g, '\\\\')}' -Force"
+      `;
+      execSync(`powershell -Command "${command}"`, { stdio: 'inherit' });
+
+      const copied = fs.existsSync(destinationScript) &&
+        fs.readFileSync(destinationScript, 'utf8') === fs.readFileSync(sourceScript, 'utf8');
+      if (!copied) {
+        throw new Error('Elevated copy did not complete (the UAC prompt may have been dismissed or denied).');
+      }
+    }
   }
 
   console.log('Bridge script installed successfully!');

--- a/src/index.ts
+++ b/src/index.ts
@@ -442,9 +442,14 @@ const LayerIdentifierSchema = {
   layerIndex: z.number().int().positive().describe("1-based index of the target layer within the composition.")
 };
 
-// Zod schema for keyframe value (more specific types might be needed depending on property)
-// Using z.any() for flexibility, but can be refined (e.g., z.array(z.number()) for position/scale)
-const KeyframeValueSchema = z.unknown().describe("The value for the keyframe (e.g., [x,y] for Position, [w,h] for Scale, angle for Rotation, percentage for Opacity)");
+// Zod schema for keyframe value. z.unknown() previously produced a typeless JSON
+// schema property, which caused MCP clients to send array/number values as a
+// stringified fallback (e.g. "[100, 200, 0]" instead of [100, 200, 0]), breaking
+// every array-valued property (Position, Scale, ...). A concrete union type keeps
+// well-behaved clients honest; setLayerKeyframe on the AE side also defensively
+// re-parses a string value as a fallback.
+const KeyframeValueSchema = z.union([z.number(), z.array(z.number())])
+  .describe("The value for the keyframe (e.g., [x,y] for Position, [w,h] for Scale, angle for Rotation, percentage for Opacity)");
 
 // Tool for setting a layer keyframe
 server.tool(

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,10 +51,13 @@ function readResultsFromTempFile(): string {
       const content = fs.readFileSync(tempFilePath, 'utf8');
       console.error(`Result file content length: ${content.length} bytes`);
       
-      // If the result file is older than 30 seconds, warn the user
-      const thirtySecondsAgo = new Date(Date.now() - 30 * 1000);
-      if (stats.mtime < thirtySecondsAgo) {
-        console.error(`WARNING: Result file is older than 30 seconds. After Effects may not be updating results.`);
+      // If the result file is older than 2 minutes, warn the user. (30s was too
+      // aggressive for interactive/chat workflows, where a few seconds routinely
+      // pass between run-script and get-results, causing false "stale" warnings
+      // on perfectly fresh results.)
+      const staleThresholdAgo = new Date(Date.now() - 120 * 1000);
+      if (stats.mtime < staleThresholdAgo) {
+        console.error(`WARNING: Result file is older than 2 minutes. After Effects may not be updating results.`);
         return JSON.stringify({ 
           warning: "Result file appears to be stale (not recently updated).",
           message: "This could indicate After Effects is not properly writing results or the MCP Bridge Auto panel isn't running.",

--- a/src/index.ts
+++ b/src/index.ts
@@ -850,7 +850,7 @@ These are internal names used by After Effects that can be used with the \`effec
 ### Blur & Sharpen
 - Gaussian Blur: "ADBE Gaussian Blur 2"
 - Camera Lens Blur: "ADBE Camera Lens Blur"
-- Directional Blur: "ADBE Directional Blur"
+- Directional Blur: "ADBE Motion Blur"
 - Radial Blur: "ADBE Radial Blur"
 - Smart Blur: "ADBE Smart Blur"
 - Unsharp Mask: "ADBE Unsharp Mask"
@@ -866,7 +866,7 @@ These are internal names used by After Effects that can be used with the \`effec
 - Vibrance: "ADBE Vibrance"
 
 ### Stylistic
-- Glow: "ADBE Glow"
+- Glow: "ADBE Glo2"
 - Drop Shadow: "ADBE Drop Shadow"
 - Bevel Alpha: "ADBE Bevel Alpha"
 - Noise: "ADBE Noise"

--- a/src/scripts/mcp-bridge-auto.jsx
+++ b/src/scripts/mcp-bridge-auto.jsx
@@ -1037,7 +1037,7 @@ function applyEffectTemplate(args) {
                 }
             },
             "directional-blur": {
-                effectMatchName: "ADBE Directional Blur",
+                effectMatchName: "ADBE Motion Blur",
                 settings: {
                     "Direction": customSettings.direction || 0,
                     "Blur Length": customSettings.length || 10
@@ -1063,12 +1063,14 @@ function applyEffectTemplate(args) {
             },
             "curves": {
                 effectMatchName: "ADBE CurvesCustom",
-                // Curves are complex and would need special handling
+                // Curves are complex and would need special handling; settings
+                // must still be an object since it's iterated with for...in below.
+                settings: {}
             },
             
             // Stylistic effects
             "glow": {
-                effectMatchName: "ADBE Glow",
+                effectMatchName: "ADBE Glo2",
                 settings: {
                     "Glow Threshold": customSettings.threshold || 50,
                     "Glow Radius": customSettings.radius || 15,
@@ -1114,7 +1116,7 @@ function applyEffectTemplate(args) {
                         }
                     },
                     {
-                        effectMatchName: "ADBE Glow",
+                        effectMatchName: "ADBE Glo2",
                         settings: {
                             "Glow Threshold": 50,
                             "Glow Radius": 10,

--- a/src/scripts/mcp-bridge-auto.jsx
+++ b/src/scripts/mcp-bridge-auto.jsx
@@ -1327,6 +1327,24 @@ function getCommandFilePath() {
     return bridgeFolder.fsName + "/ae_command.json";
 }
 
+// ExtendScript's JS engine (ES3) has no Date.prototype.toISOString, so build it manually.
+function toISOTimestamp(date) {
+    date = date || new Date();
+    function pad(n, width) {
+        n = String(n);
+        width = width || 2;
+        while (n.length < width) { n = "0" + n; }
+        return n;
+    }
+    return date.getUTCFullYear() + "-" +
+        pad(date.getUTCMonth() + 1) + "-" +
+        pad(date.getUTCDate()) + "T" +
+        pad(date.getUTCHours()) + ":" +
+        pad(date.getUTCMinutes()) + ":" +
+        pad(date.getUTCSeconds()) + "." +
+        pad(date.getUTCMilliseconds(), 3) + "Z";
+}
+
 // Result file path - use Documents folder for reliable access
 function getResultFilePath() {
     var userFolder = Folder.myDocuments;
@@ -1608,7 +1626,7 @@ function executeCommand(command, args) {
         try {
             var resultObj = JSON.parse(resultString);
             // Add a timestamp to help identify if we're getting fresh results
-            resultObj._responseTimestamp = new Date().toISOString();
+            resultObj._responseTimestamp = toISOTimestamp();
             resultObj._commandExecuted = command;
             resultString = JSON.stringify(resultObj, null, 2);
             logToPanel("Added timestamp to result JSON for tracking freshness.");

--- a/src/scripts/mcp-bridge-auto.jsx
+++ b/src/scripts/mcp-bridge-auto.jsx
@@ -792,6 +792,15 @@ function setLayerKeyframe(compIndex, layerIndex, propertyName, timeInSeconds, va
              property.setValueAtTime(comp.time, property.value); // Set initial keyframe if none exist
         }
 
+        // Some MCP clients send array/number values JSON-stringified (e.g.
+        // "[100, 200, 0]" instead of [100, 200, 0]); normalize defensively.
+        if (typeof value === "string") {
+            try {
+                value = JSON.parse(value);
+            } catch (parseErr) {
+                // Leave as-is; setValueAtTime below will report a clear error.
+            }
+        }
 
         property.setValueAtTime(timeInSeconds, value);
 


### PR DESCRIPTION
## Summary

While testing the MCP bridge end-to-end against a real After Effects 2026 install (Spanish locale), I found and fixed 6 bugs. Every fix below was verified live: I re-ran the failing command against After Effects after each change and confirmed success.

1. **`Date().toISOString` doesn't exist in ExtendScript (ES3)** — `mcp-bridge-auto.jsx` was throwing (silently, into a try/catch) on every command, so responses never got their `_responseTimestamp`/`_commandExecuted` fields. Added a manual `toISOTimestamp()` formatter.

2. **"Stale result" threshold too aggressive** — `readResultsFromTempFile` in `index.ts` flagged results older than 30s as stale, which is routinely exceeded in an interactive chat workflow between `run-script` and `get-results` even when the result is perfectly fresh. Raised to 120s.

3. **`install-bridge.js` lied about success on Windows** — the elevated-copy fallback used `Start-Process -Verb RunAs` without `-Wait`, so `execSync` returned as soon as the elevated process *launched*, not when the copy finished, and the result was never verified. It printed "installed successfully!" even when the UAC prompt was dismissed and nothing was copied. Now tries a direct (non-elevated) copy first — mirroring the existing macOS behavior — and only falls back to an elevated, waited, and verified copy if that fails.

4. **Wrong/missing effect matchNames in `applyEffectTemplate`** — verified by applying every one of the 9 templates against a real layer:
   - `glow` / `text-pop` used `"ADBE Glow"`, which AE rejects. The real matchName is `"ADBE Glo2"`.
   - `directional-blur` used `"ADBE Directional Blur"`, also rejected. Real matchName is `"ADBE Motion Blur"`.
   - `curves` had no `settings` key at all, so `for (propName in template.settings)` threw `TypeError: undefined no es un objeto` in ExtendScript. Added `settings: {}`.

5. **`setLayerKeyframe` array values arriving as stringified JSON** — `KeyframeValueSchema` used `z.unknown()`, producing a typeless JSON schema property. This caused array values (e.g. `Position: [100, 200, 0]`) to arrive at the AE side as the literal string `"[100, 200, 0]"`, which `setValueAtTime` rejected. Gave the schema a concrete type (`z.union([z.number(), z.array(z.number())])`) and added a defensive `JSON.parse` fallback on the ExtendScript side for any client that still stringifies it.

6. **`get-effects-help` documented the same wrong matchNames as bug #4** — anyone copying `"ADBE Glow"` / `"ADBE Directional Blur"` from the help text into `apply-effect` would hit the same failure. Corrected.

## Testing

Verified live against After Effects 2026 (Spanish locale) by running essentially every documented bridge command: `getProjectInfo`, `listCompositions`, `createComposition`, `createTextLayer`, `createShapeLayer`, `createSolidLayer`, `createCamera`, `setLayerProperties`, `batchSetLayerProperties`, `setCompositionProperties`, `duplicateLayer`, `deleteLayer`, `setLayerMask`, `setLayerKeyframe`, `setLayerExpression`, `applyEffect`, `applyEffectTemplate` (all 9 templates), and `bridgeTestEffects`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)